### PR TITLE
Load CSS in Django views

### DIFF
--- a/chartwerk/templates/chartwerk/base.html
+++ b/chartwerk/templates/chartwerk/base.html
@@ -1,3 +1,4 @@
+{%load staticfiles%}
 <!DOCTYPE html>
 <html>
     <head>
@@ -9,6 +10,8 @@
 
         <meta name="viewport" content="width=device-width, initial-scale=1">
 
+        <link rel="stylesheet" href="{% static 'chartwerk/css/vendor.css' %}" media="screen" title="no title" charset="utf-8">
+        <link rel="stylesheet" href="{% static 'chartwerk/css/shared/styles.css' %}" media="screen" title="no title" charset="utf-8">
 
 
 

--- a/chartwerk/templates/chartwerk/home.html
+++ b/chartwerk/templates/chartwerk/home.html
@@ -8,7 +8,6 @@
 {%endblock%}
 
 {%block content%}
-
 <div class="header">
     <h1>
         <a href="{%url 'chartwerk_home'%}">Chartwerk</a>


### PR DESCRIPTION
Views are partially unstyled in the current version:
![screen shot 2017-06-01 at 4 07 59 pm](https://cloud.githubusercontent.com/assets/682828/26700834/84a9e6fe-46e4-11e7-8a2c-46c02b4af561.png)

This adds what I think are the two missing CSS files (vendor.css and shared.css).