### PR TITLE
Celery task fixes

### DIFF
--- a/chartwerk/tasks/slack.py
+++ b/chartwerk/tasks/slack.py
@@ -4,31 +4,28 @@ import logging
 import os
 import time
 
-from slacker import Slacker
-
 from celery import shared_task
-from chartwerk.models import Chartwerk, Template
+from slacker import Slacker
 from django.conf import settings
 from django.contrib.staticfiles.templatetags.staticfiles import static
+
+from chartwerk.models import Chart, Template
+
 
 logger = logging.getLogger(__name__)
 
 DOMAIN = settings.CHARTWERK_DOMAIN
 
-slack = False
-if 'CHARTWERK_SLACK_TOKEN' in os.environ:
-    slack = Slacker(os.getenv('CHARTWERK_SLACK_TOKEN'))
-
 
 def get_template_icon(template_title):
     """Get template's icon."""
     template = Template.objects.filter(title=template_title).first()
-    if template.icon:
+    if template is not None and template.icon:
         return template.icon.url
     return ''
 
 
-def get_slack_user(email):
+def get_slack_user(slack, email):
     """Get a Slack user by email."""
     users = slack.users.list().body['members']
     user = 'a stranger'
@@ -44,38 +41,43 @@ def get_slack_user(email):
 @shared_task
 def notify_slack(pk):
     """Send slack notification."""
-    werk = Chartwerk.objects.get(pk=pk)
+    werk = Chart.objects.get(pk=pk)
+
+    if not hasattr(settings, 'CHARTWERK_SLACK_TOKEN'):
+        return
+
+    slack = Slacker(settings.CHARTWERK_SLACK_TOKEN)
+
     try:
-        if slack:
-            chart_url = os.path.join(DOMAIN, 'chart', werk.slug)
-            attachmentData = [{
-                'fallback': '{} created a new chart, "{}" at {}/'.format(
-                    get_slack_user(werk.author),
-                    werk.title,
-                    chart_url
-                ),
-                'color': '#C91507',
-                'pretext': 'New chart by {}'.format(
-                    get_slack_user(werk.author)
-                ),
-                'title': werk.title,
-                'title_link': '{}/'.format(chart_url),
-                'text': werk.data['template']['title'],
-                'thumb_url': get_template_icon(
-                    werk.data['template']['title']
-                ),
-                'footer': 'chartwerk',
-                'footer_icon': os.path.join(
-                    DOMAIN,
-                    static('chartwerk/img/chartwerk_30.png')[1:]
-                ),
-                'ts': int(time.time())
-            }]
-            slack.chat.post_message(
-                settings.CHARTWERK_SLACK_CHANNEL,
-                '',
-                as_user=True,
-                attachments=attachmentData
-            )
+        chart_url = os.path.join(DOMAIN, 'chart', werk.slug)
+        attachmentData = [{
+            'fallback': '{} created a new chart, "{}" at {}/'.format(
+                get_slack_user(slack, werk.author),
+                werk.title,
+                chart_url
+            ),
+            'color': '#C91507',
+            'pretext': 'New chart by {}'.format(
+                get_slack_user(slack, werk.author)
+            ),
+            'title': werk.title,
+            'title_link': '{}/'.format(chart_url),
+            'text': werk.data['template']['title'],
+            'thumb_url': get_template_icon(
+                werk.data['template']['title']
+            ),
+            'footer': 'chartwerk',
+            'footer_icon': os.path.join(
+                DOMAIN,
+                static('chartwerk/img/chartwerk_30.png')[1:]
+            ),
+            'ts': int(time.time())
+        }]
+        slack.chat.post_message(
+            settings.CHARTWERK_SLACK_CHANNEL,
+            '',
+            as_user=True,
+            attachments=attachmentData
+        )
     except Exception:
         logging.exception("Slack notification error")


### PR DESCRIPTION
I had to change a few things to get Celery tasks working:
- query `Chart` and not `Chartwerk` to load chart instances
- rely on what's in the Django `settings` dict, not the environment; in our case, we were defining things in settings but tasks weren't running because they weren't also in the environment
- initialize session with the AWS and Slack APIs inside the Celery tasks that use them so they're not instantiated for Web workers and can use Django's `settings`
- deal with cases where `get_template_icon` can't find a matching `Template` and therefore no icon (I don't fully understand why these would not be found, so this is a hacky fix for now ...)