### PR TITLE
Fix GitHub task

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,118 +119,81 @@ Chartwerk allows you to set a number of configuration options. The preferred met
 
 ### App settings
 
-- `CHARTWERK_AUTH_DECORATOR`
+- `CHARTWERK_AUTH_DECORATOR`: String module path to a decorator that should be applied to Chartwerk views to authenticate users. Defaults to `"django.contrib.auth.decorators.login_required"`, but can also be `"django.contrib.admin.views.decorators.staff_member_required"`, for example. (This decorator is not applied to views in DEBUG mode.)
 
-String module path to a decorator that should be applied to Chartwerk views to authenticate users. Defaults to `"django.contrib.auth.decorators.login_required"`, but can also be `"django.contrib.admin.views.decorators.staff_member_required"`, for example. (This decorator is not applied to views in DEBUG mode.)
+- `CHARTWERK_DB`: If you aren't using PostgreSQL in your main project, you can separate the database for django-chartwerk from your other apps. Add the CHARTWERK_DB environment variable, a la [DATABASE_URL](https://github.com/kennethreitz/dj-database-url). You can also add the database explicitly to the DATABASES dict in project settings as `"chartwerk"`.
 
-- `CHARTWERK_DB`
+- `CHARTWERK_COLOR_SCHEMES`: Set this variable in your project settings to declare a default set of color schemes your users can select for chart elements. The schemes must be organized by type as a dictionary with keys `categorical`, `sequential` and `diverging`. Name each color scheme and then provide a list of hexadecimal color codes. For example:
 
-If you aren't using PostgreSQL in your main project, you can separate the database for django-chartwerk from your other apps. Add the CHARTWERK_DB environment variable, a la [DATABASE_URL](https://github.com/kennethreitz/dj-database-url). You can also add the database explicitly to the DATABASES dict in project settings as `"chartwerk"`.
-
-- `CHARTWERK_COLOR_SCHEMES`
-
-Set this variable in your project settings to declare a default set of color schemes your users can select for chart elements. The schemes must be organized by type as a dictionary with keys `categorical`, `sequential` and `diverging`. Name each color scheme and then provide a list of hexadecimal color codes. For example:
-
-```python
-# settings.py
-CHARTWERK_COLOR_SCHEMES = {
-    'categorical': {
-        'default': [
-            '#AAAAAA',
-            '#BBB'
-            # etc.
-        ],
+    ```python
+    # settings.py
+    CHARTWERK_COLOR_SCHEMES = {
+        'categorical': {
+            'default': [
+                '#AAAAAA',
+                '#BBB'
+                # etc.
+            ],
+        }
+        'sequential': {
+            'reds': [
+                '#FF0000',
+                '#8B0000',
+                # etc.
+            ],
+            'blues': [
+                '#0000FF,
+                '#000080',
+                # etc.
+            ]
+        },
+        'diverging': {
+            'redBlue': [
+                '#FF0000',
+                '#0000FF',
+                # etc.
+            ]
+        }
     }
-    'sequential': {
-        'reds': [
-            '#FF0000',
-            '#8B0000',
-            # etc.
-        ],
-        'blues': [
-            '#0000FF,
-            '#000080',
-            # etc.
-        ]
-    },
-    'diverging': {
-        'redBlue': [
-            '#FF0000',
-            '#0000FF',
-            # etc.
-        ]
-    }
-}
-```
+    ```
 
 ### AWS Publishing
 
-- `AWS_ACCESS_KEY_ID`
+- `AWS_ACCESS_KEY_ID`: AWS access key ID. See [Environment Variables config for Boto3](http://boto3.readthedocs.io/en/latest/guide/configuration.html#environment-variables).
 
-AWS access key ID. See [Environment Variables config for Boto3](http://boto3.readthedocs.io/en/latest/guide/configuration.html#environment-variables). **Required as environment variable**
+- `AWS_SECRET_ACCESS_KEY`: AWS secret access key. See [Environment Variables config for Boto3](http://boto3.readthedocs.io/en/latest/guide/configuration.html#environment-variables).
 
-- `AWS_SECRET_ACCESS_KEY`
+- `CHARTWERK_AWS_BUCKET`: AWS S3 bucket name to publish charts to. **Required.**
 
-AWS secret access key. See [Environment Variables config for Boto3](http://boto3.readthedocs.io/en/latest/guide/configuration.html#environment-variables). **Required as environment variable.**
+- `CHARTWERK_AWS_PATH`: Path within your S3 bucket to append to object keys before publishing. Defaults to `"charts"`
 
-- `CHARTWERK_AWS_BUCKET`
+- `CHARTWERK_CACHE_HEADER`: Cache header to add to chart files when published to S3. Defaults to `"max-age=300"`.
 
-AWS S3 bucket name to publish charts to. **Required.**
+- `CHARTWERK_DOMAIN`: The domain of the app running Chartwerk. For example, your app may be hosted at `"http://myapp.mydomain.com"`. **Required.**
 
-- `CHARTWERK_AWS_PATH`
+- `CHARTWERK_EMBED_SCRIPT`: Absolute URL to your custom script for embedding Chartwerk charts in your CMS. **Required.**
 
-Path within your S3 bucket to append to object keys before publishing. Defaults to `"charts"`
+- `CHARTWERK_JQUERY`: URL to jQuery version you want to include in baked-out charts. Defaults to `"https://code.jquery.com/jquery-3.2.1.slim.min.js"`.
 
-- `CHARTWERK_CACHE_HEADER`
-
-Cache header to add to chart files when published to S3. Defaults to `"max-age=300"`.
-
-- `CHARTWERK_DOMAIN`
-
-The domain of the app running Chartwerk. For example, your app may be hosted at `"http://myapp.mydomain.com"`. **Required.**
-
-- `CHARTWERK_EMBED_SCRIPT`
-
-Absolute URL to your custom script for embedding Chartwerk charts in your CMS. **Required.**
-
-- `CHARTWERK_JQUERY`
-
-URL to jQuery version you want to include in baked-out charts. Defaults to `"https://code.jquery.com/jquery-3.2.1.slim.min.js"`.
-
-
-- `CHARTWERK_OEMBED`
-
-If your CMS is configured to use oEmbed, set this setting to `True` which will return oEmbed code to users in the editor. Default is `False`.
+- `CHARTWERK_OEMBED`: If your CMS is configured to use oEmbed, set this setting to `True` which will return oEmbed code to users in the editor. Default is `False`.
 
 
 ### Github
 
 django-chartwerk can commit your chart templates to a GitHub repository for safe keeping.
 
-- `CHARTWERK_GITHUB_ORG`
+- `CHARTWERK_GITHUB_ORG`: To keep templates in a repo under a GitHub organization, set this variable to the GitHub org name.
 
-To keep templates in a repo under a GitHub organization, set this variable to the GitHub org name.
+- `CHARTWERK_GITHUB_REPO`: The name of the repo to save chart templates to. Defaults to `"chartwerk_chart-templates"`.
 
-- `CHARTWERK_GITHUB_PASSWORD`
+- `CHARTWERK_GITHUB_USER`, `CHARTWERK_GITHUB_PASSWORD`: GitHub username and password.
 
-GitHub user password. Can only be set as an environment variable.
-
-- `CHARTWERK_GITHUB_REPO`
-
-The name of the repo to save chart templates to. Defaults to `"chartwerk_chart-templates"`.
-
-- `CHARTWERK_GITHUB_USER`
-
-GitHub username. Can only be set as an environment variable.
+- `CHARTWERK_GITHUB_TOKEN`: GitHub personal access token with writes to edit private repositories. Can only be set in lieu of `CHARTWERK_GITHUB_USER` and `CHARTWERK_GITHUB_PASSWORD`.
 
 ### Slack
 
 Chartwerk can send notifications to a Slack channel whenever a new chart is created.
 
-- `CHARTWERK_SLACK_CHANNEL`
+- `CHARTWERK_SLACK_CHANNEL`: Name of the Slack channel to post notifications to. Defaults to `"#chartwerk"`.
 
-Name of the Slack channel to post notifications to. Defaults to `"#chartwerk"`.
-
-- `CHARTWERK_SLACK_TOKEN`
-
-A Slack API token.
+- `CHARTWERK_SLACK_TOKEN`: A Slack API token.

--- a/chartwerk/tasks/github.py
+++ b/chartwerk/tasks/github.py
@@ -2,80 +2,107 @@
 from __future__ import absolute_import
 import json
 import logging
-import os
 
 from celery import shared_task
-from chartwerk.models import Template
 from django.conf import settings
-from github import Github
+from github import Github, GithubException, UnknownObjectException
+
+from chartwerk.models import Template
+
 
 logger = logging.getLogger(__name__)
 
-repository = False
-if 'CHARTWERK_GITHUB_USER' in os.environ and \
-        'CHARTWERK_GITHUB_PASSWORD' in os.environ:
+
+def get_github_credentials():
+    """Get the credentials kwargs we're going to pass to Github()"""
     try:
-        repo_name = settings.CHARTWERK_GITHUB_REPO
-        g = Github(
-            os.getenv('CHARTWERK_GITHUB_USER'),
-            os.getenv('CHARTWERK_GITHUB_PASSWORD')
-        )
-        user = g.get_user()
-        if settings.CHARTWERK_GITHUB_ORG:
-            user = g.get_organization(settings.CHARTWERK_GITHUB_ORG)
+        return dict(login_or_token=settings.CHARTWERK_GITHUB_TOKEN)
+    except AttributeError:
         try:
-            repository = user.get_repo(repo_name)
-        except:
-            repository = user.create_repo(repo_name)
+            return dict(
+                login_or_token=settings.CHARTWERK_GITHUB_USER,
+                password=settings.CHARTWERK_GITHUB_PASSWORD
+            )
+        except AttributeError:
+            pass
+
+
+def get_repository():
+    """Get the Github repo specified in settings, adding if it doesn't exist"""
+    try:
+        repo_name = getattr(
+            settings,
+            'CHARTWERK_GITHUB_REPO',
+            'chartwerk_chart-templates'
+        )
+    except AttributeError:
+        return None
+
+    try:
+        g = Github(**get_github_credentials())
+
+        if hasattr(settings, 'CHARTWERK_GITHUB_ORG'):
+            user = g.get_organization(settings.CHARTWERK_GITHUB_ORG)
+        else:
+            user = g.get_user()
+
+        try:
+            return user.get_repo(repo_name)
+        except UnknownObjectException:
             logging.info("Creating repository {}".format(repo_name))
-    except:
+            return user.create_repo(repo_name)
+    except GithubException:
         logging.exception("Unable to configure Github connection.")
 
 
 def commit_script(path, script):
     """Commit script string to github repo."""
+    repository = get_repository()
+
     try:
-        try:
-            sha = repository.get_contents(path).sha
-            repository.update_file(
-                path=path,
-                message='Template update',
-                content=script,
-                sha=sha
-            )
-        except:
-            repository.create_file(
-                path=path,
-                message='Template initial commit',
-                content=script
-            )
-            logging.info("Initial commit of new file {}".format(path))
-    except Exception:
-        logging.exception("Unable to commit to github repo")
+        sha = repository.get_contents(path).sha
+        repository.update_file(
+            path=path,
+            message='Template update',
+            content=script,
+            sha=sha
+        )
+    except GithubException:
+        repository.create_file(
+            path=path,
+            message='Template initial commit',
+            content=script
+        )
+        logging.info("Initial commit of new file {}".format(path))
 
 
 @shared_task
 def commit_template(pk):
-    template = Template.objects.get(pk=pk)
     """Commit template scripts to github."""
-    if repository:
-        commit_script(
-            '/{}/draw.js'.format(template.slug),
-            template.data['scripts']['draw']
-        )
-        commit_script(
-            '/{}/helper.js'.format(template.slug),
-            template.data['scripts']['helper']
-        )
-        commit_script(
-            '/{}/chart.html'.format(template.slug),
-            template.data['scripts']['html']
-        )
-        commit_script(
-            '/{}/styles.css'.format(template.slug),
-            template.data['scripts']['styles']
-        )
-        commit_script(
-            '/{}/template.json'.format(template.slug),
-            json.dumps(template.data)
-        )
+    repository = get_repository()
+
+    if repository is None:
+        return
+
+    template = Template.objects.get(pk=pk)
+
+    commit_script(
+        '/{}/draw.js'.format(template.slug),
+        template.data['scripts']['draw']
+    )
+    commit_script(
+        '/{}/helper.js'.format(template.slug),
+        template.data['scripts']['helper']
+    )
+    commit_script(
+        '/{}/chart.html'.format(template.slug),
+        template.data['scripts']['html']
+    )
+    commit_script(
+        '/{}/styles.css'.format(template.slug),
+        template.data['scripts']['styles']
+    )
+    commit_script(
+        '/{}/template.json'.format(template.slug),
+        json.dumps(template.data)
+    )

--- a/chartwerk/tasks/github.py
+++ b/chartwerk/tasks/github.py
@@ -1,4 +1,4 @@
-"""Celery task to commit template tasks to github."""
+"""Celery task to commit templates to GitHub."""
 from __future__ import absolute_import
 import json
 import logging
@@ -14,7 +14,10 @@ logger = logging.getLogger(__name__)
 
 
 def get_github_credentials():
-    """Get the credentials kwargs we're going to pass to Github()"""
+    """Get the credentials kwargs we're going to pass to Github().
+    
+    Prefers a personal token over a username/password.
+    """
     try:
         return dict(login_or_token=settings.CHARTWERK_GITHUB_TOKEN)
     except AttributeError:
@@ -28,7 +31,10 @@ def get_github_credentials():
 
 
 def get_repository():
-    """Get the Github repo specified in settings, adding if it doesn't exist"""
+    """Get the GitHub repo specified in settings or the default.
+    
+    If the repo doesn't exist, try to create it.
+    """
     try:
         repo_name = getattr(
             settings,
@@ -56,7 +62,7 @@ def get_repository():
 
 
 def commit_script(path, script):
-    """Commit script string to github repo."""
+    """Commit script string to GitHub repo."""
     repository = get_repository()
 
     try:
@@ -78,7 +84,7 @@ def commit_script(path, script):
 
 @shared_task
 def commit_template(pk):
-    """Commit template scripts to github."""
+    """Commit template scripts to GitHub."""
     repository = get_repository()
 
     if repository is None:

--- a/chartwerk/tasks/github.py
+++ b/chartwerk/tasks/github.py
@@ -104,5 +104,5 @@ def commit_template(pk):
     )
     commit_script(
         '/{}/template.json'.format(template.slug),
-        json.dumps(template.data)
+        json.dumps(template.data, sort_keys=True, indent=4)
     )


### PR DESCRIPTION
This does a few things to get the Github functionality working:
- auths Github using values from the settings file, not the by directly reading env vars (consistent with #13)
- allows for a personal access token instead of user name and password
- tries to capture specific named exceptions instead of `Exception`
- initialize session with the Github APIs inside the Celery tasks, not on module init (consistent with #13)
- applies default repo name specified in README if one isn't provided
- beautifies JSON in template.json on commit