### PR TITLE
URLs to Chartwerk should include app directory from root URL conf

### DIFF
--- a/chartwerk/models.py
+++ b/chartwerk/models.py
@@ -7,6 +7,7 @@ from datetime import datetime
 from django.conf import settings
 from django.contrib.postgres.fields import JSONField
 from django.db import models
+from django.urls import reverse
 from django.utils.text import slugify
 from uuslug import uuslug
 
@@ -80,7 +81,10 @@ class Chart(Chartwerk):
             "version": "1.0",
             "url": url,
             "title": self.title,
-            "provider_url": settings.CHARTWERK_DOMAIN,
+            "provider_url": os.path.join(
+                settings.CHARTWERK_DOMAIN,
+                reverse('chartwerk_home')[1:]
+            ),
             "provider_name": "Chartwerk",
             "author_name": self.creator,
             "chart_id": self.slug,
@@ -118,7 +122,7 @@ class Template(Chartwerk):
         self.slug = uuslug(self.title, instance=self)
         super(Template, self).save(*args, **kwargs)
 
-    def __str__(self): # noqa
+    def __str__(self):
         return self.slug
 
 
@@ -139,7 +143,7 @@ class TemplateProperty(models.Model):
         self.slug = uuslug(self.property, instance=self)
         super(TemplateProperty, self).save(*args, **kwargs)
 
-    def __str__(self): # noqa
+    def __str__(self):
         return self.property
 
     class Meta:
@@ -150,5 +154,5 @@ class FinderQuestion(models.Model):
     question = models.CharField(max_length=250)
     order = models.PositiveSmallIntegerField(unique=True)
 
-    def __str__(self): # noqa
+    def __str__(self):
         return self.question

--- a/chartwerk/tasks/slack.py
+++ b/chartwerk/tasks/slack.py
@@ -8,6 +8,7 @@ from celery import shared_task
 from slacker import Slacker
 from django.conf import settings
 from django.contrib.staticfiles.templatetags.staticfiles import static
+from django.urls import reverse
 
 from chartwerk.models import Chart, Template
 
@@ -48,9 +49,12 @@ def notify_slack(pk):
     slack = Slacker(settings.CHARTWERK_SLACK_TOKEN)
 
     try:
-        chart_url = os.path.join(DOMAIN, 'chart', werk.slug)
+        chart_url = os.path.join(
+            DOMAIN,
+            reverse('chartwerk_chart', kwargs={'slug': werk.slug})[1:]
+        )
         attachmentData = [{
-            'fallback': '{} created a new chart, "{}" at {}/'.format(
+            'fallback': '{} created a new chart, "{}" at {}'.format(
                 get_slack_user(slack, werk.author),
                 werk.title,
                 chart_url
@@ -60,7 +64,7 @@ def notify_slack(pk):
                 get_slack_user(slack, werk.author)
             ),
             'title': werk.title,
-            'title_link': '{}/'.format(chart_url),
+            'title_link': chart_url,
             'text': werk.data['template']['title'],
             'thumb_url': get_template_icon(
                 werk.data['template']['title']


### PR DESCRIPTION
When Chartwerk is installed into a project and mounted in a subdirectory there two URLs that break - the `provider_url` in the oEmbed endpoint and the link to the chart that's posted to Slack. This fixes that by using `reverse()` to generate those URLs.