### PR TITLE
Closes #15: Template writes fail w/o matching TemplateProperty

### DIFF
--- a/chartwerk/fixtures/free_templates.json
+++ b/chartwerk/fixtures/free_templates.json
@@ -1,1 +1,3550 @@
-[{"model": "chartwerk.template", "pk": 5, "fields": {"slug": "line-chart", "title": "Line chart", "data": {"text": {"chatter": "Rising faster than expected, industry rebounds.", "annotations": [], "source": "SOURCE: New York Stock Exchange", "legend": {"single": {"inside": false, "position": {"x": 10, "y": 10}, "align": "l", "background": true, "width": 250}, "double": {"inside": false, "position": {"x": 10, "y": 10}, "align": "l", "background": true, "width": 500}, "title": "", "active": true, "keys": [{"text": "CBM", "color": "#329CEB"}, {"text": "GQS", "color": "#E34E36"}]}, "author": "John Doe / DMN", "headline": "Stock prices rise", "title": "", "footnote": ""}, "template": {"icon": null, "tags": ["time-series"], "description": "Line charts are used to show continuous data over time. Examples include stock prices, temperatures, indexes and rates.\n\nThe X axis (base axis) on a line chart always runs along a date range, for example, 1992 to 2012. \n\nYour data should include one column of dates. Check out the available date formats on the Axes tab, and format your dates in your spreadsheet according to one of these.\n\nYou should have one column of data for each line in your chart.", "title": "Line chart"}, "embed": {"dimensions": {}}, "scripts": {"helper": "var werkHelper = {\n    parse: function(werk){\n        werk.parsers = {\n          base: d3.timeParse( chartwerk.axes.base.dateFormat ),\n          value: function(d){ return d === '' ? NaN : +d; }\n        };\n        \n        werk.data = chartwerk.axes.color.domain.map(function(category){\n            return {\n                name: category,\n                values: chartwerk.data.map(function(d){\n                    return {\n                        x: werk.parsers.base(\n                            String(d[chartwerk.datamap.base])\n                        ),\n                        y: werk.parsers.value(d[category])\n                    };\n                })\n                .sort(function(a, b){ return d3.ascending(a.x, b.x); })\n            };\n        });\n        \n        // Get max and min of data \n        var xMax = d3.max(werk.data,function(series){return d3.max(series.values,function(d){return d.x; }); }),\n\t        xMin = d3.min(werk.data,function(series){return d3.min(series.values,function(d){return d.x; }); }),\n\t        yMax = d3.max(werk.data,function(series){return d3.max(series.values,function(d){return d.y; }); }),\n\t        yMin = d3.min(werk.data,function(series){return d3.min(series.values,function(d){return d.y; }); });\n        \n        werk.dataDims = {\n            xMin: xMin,\n            xMax: xMax,\n            yMin: yMin,\n            yMax: yMax\n        };\n    },\n    \n    dims: function(werk){\n        var s = chartwerk.ui.size;\n            w = werk.dims[s].width,\n            h = werk.dims[s].height,\n            margins = {\n                right: chartwerk.margins[s].right * w,\n                left: chartwerk.margins[s].left * w,\n                top: chartwerk.margins[s].top * h,\n                bottom: chartwerk.margins[s].bottom * h\n            },\n            svg = {\n                width: w - margins.left - margins.right,\n                height: h - margins.top - margins.bottom\n            };\n        \n        werk.dims.margins = margins;\n        werk.dims.svg = svg;\n    },\n\n    scales: function(werk){\n        var svg = werk.dims.svg;\n        werk.scales = {\n            x: d3.scaleTime()\n                .range([0, svg.width]),\n            y: d3.scaleLinear()\n                .range([svg.height, 0]),\n            color: chartwerk.axes.color.range.length > 1 ? \n                d3.scaleOrdinal()\n                  .domain(chartwerk.axes.color.domain)\n                  .range(chartwerk.axes.color.range) \n            :   function(d){return chartwerk.axes.color.range[0];},\n        };\n    },\n    \n    baseDomain:  function(werk){\n        var xMax = d3.max(werk.data, function(category) {\n                return d3.max(category.values, function(d){\n                    return d.x; \n                }); \n            }),\n            xMin = d3.min(werk.data, function(category) { \n                return d3.min(category.values, function(d){ \n                    return d.x;\n                });\n            });\n        werk.scales.x.domain([xMin, xMax]);\n    },\n\n    valueDomain: function(werk){\n        var yMax = d3.max(werk.data, function(category) { \n                return d3.max(category.values, function(d){ \n                    return d.y; \n                }); \n            }),\n            yMin = d3.min(werk.data, function(category) {\n                return d3.min(category.values, function(d){ \n                    return d.y; \n                }); \n            });\n        \n        if (chartwerk.axes.value.min && chartwerk.axes.value.max) {\n            werk.scales.y.domain(\n                [chartwerk.axes.value.min, chartwerk.axes.value.max]\n            );\n        } else if (chartwerk.axes.value.min) {\n            werk.scales.y.domain(\n                [chartwerk.axes.value.min, yMax ]\n            );\n        } else if (chartwerk.axes.value.max) {\n            werk.scales.y.domain(\n                [yMin, chartwerk.axes.value.max]\n            );\n        } else {\n            werk.scales.y.domain([yMin, yMax]);\n        }\n        \n        werk.scales.y.nice();\n    },\n\n    axes: function(werk){\n        werk.axes = {\n          x: d3.axisBottom(werk.scales.x)\n              .tickSizeInner(6)\n              .tickSizeOuter(0)\n              .tickPadding(3),\n          y: d3.axisLeft(werk.scales.y)\n              .tickSizeInner(-werk.dims.svg.width)\n              .tickSizeOuter(0)\n              .tickPadding(7)\n              .tickFormat( function(d){ \n                var formatter = werk.scales.y.tickFormat();\n                if (d >= 0) {\n                  return formatter(d) === '0' ? '0' : \n                  chartwerk.axes.value.prefix + formatter(d) + chartwerk.axes.value.suffix;\n                } else {\n                  return \"-\" + chartwerk.axes.value.prefix + formatter(Math.abs(d)) + chartwerk.axes.value.suffix;\n                }\n              }),\n        };\n    },\n\n    baseTicks: function(werk){\n        if (chartwerk.axes.base.type !== 'date') {\n            return;\n        }\n        \n        // Abstract this to a separate file once formats settled.\n        var customLocale = {\n          \"dateTime\": \"%x, %X\",\n          \"date\": \"%-m/%-d/%Y\",\n          \"time\": \"%-I:%M:%S %p\",\n          \"periods\": [\"AM\", \"PM\"],\n          \"days\": [\"Sunday\", \"Monday\", \"Tuesday\", \"Wednesday\", \"Thursday\", \"Friday\", \"Saturday\"],\n          \"shortDays\": [\"S\", \"M\", \"T\", \"W\", \"T\", \"F\", \"S\"],\n          \"months\": [\"January\", \"February\", \"March\", \"April\", \"May\", \"June\", \"July\", \"August\", \"September\", \"October\", \"November\", \"December\"],\n          \"shortMonths\": [\"Jan\", \"Feb\", \"Mar\", \"Apr\", \"May\", \"Jun\", \"Jul\", \"Aug\", \"Sep\", \"Oct\", \"Nov\", \"Dec\"]\n        }\n        \n        d3.timeFormatDefaultLocale(customLocale);\n        \n        \n        var formatMillisecond = d3.timeFormat(\".%L\"),\n            formatSecond = d3.timeFormat(\":%S\"),\n            formatMinute = d3.timeFormat(\"%I:%M\"),\n            formatHour = d3.timeFormat(\"%I %p\"),\n            formatDay = d3.timeFormat(\"%a %d\"),\n            formatWeek = d3.timeFormat(\"%b %d\"),\n            formatMonth = d3.timeFormat(\"%B\"),\n            formatYear = d3.timeFormat(\"%Y\");\n        \n        \n        var s = chartwerk.ui.size;\n        var dateTick;\n        switch(chartwerk.axes.base.format[s].dateString) {\n            case 'Y':\n                dateTick = d3.timeYear;\n                formatYear = d3.timeFormat(\"%Y\");\n                break;\n            case 'y':\n                dateTick = d3.timeYear;\n                formatYear = d3.timeFormat(\"'%y\");\n                break;\n            case 'M':\n                dateTick = d3.timeMonth;\n                formatMonth = d3.timeFormat(\"%B\");\n                formatYear = d3.timeFormat(\"Jan. '%y\");\n                break;\n            case 'm':\n                dateTick = d3.timeMonth;\n                formatMonth = d3.timeFormat(\"%b.\");\n                formatYear = d3.timeFormat(\"J/%y\");\n                break;\n            case 'W':\n            case 'w':\n                dateTick = d3.timeWeek;\n                formatMonth = d3.timeFormat(\"%b.\");\n                formatYear = d3.timeFormat(\"J/%y\");\n                break;\n            case 'D':\n                dateTick = d3.timeDay;\n                formatMonth = d3.timeFormat(\"%b.\");\n                formatYear = d3.timeFormat(\"J/%y\");\n        }\n        \n        function multiFormat(date) {\n          return (d3.timeSecond(date) < date ? formatMillisecond\n              : d3.timeMinute(date) < date ? formatSecond\n              : d3.timeHour(date) < date ? formatMinute\n              : d3.timeDay(date) < date ? formatHour\n              : d3.timeMonth(date) < date ? (d3.timeWeek(date) < date ? formatDay : formatWeek)\n              : d3.timeYear(date) < date ? formatMonth\n              : formatYear)(date);\n        }\n        \n        werk.axes.x.tickFormat(multiFormat)\n        \n        werk.axes.x.ticks(\n            dateTick.every( chartwerk.axes.base.format[s].frequency )\n        );\n    },\n\n    valueTicks: function(werk){\n        var s = chartwerk.ui.size;\n        if (chartwerk.axes.value.format[s].customTicks.length > 0) { \n            werk.axes.y.tickValues(\n                chartwerk.axes.value.format[s].customTicks\n            );\n        } else {\n            werk.axes.y.ticks(\n              chartwerk.axes.value.format[s].ticks\n            );\n        }\n    },\n\n    // Build dims, scales and axes.\n    build: function(werk){\n        this.parse(werk);\n        this.dims(werk);\n        this.scales(werk);\n        this.baseDomain(werk);\n        this.valueDomain(werk);\n        this.axes(werk);\n        this.baseTicks(werk);\n        this.valueTicks(werk);\n        return werk;\n    },\n};", "draw": "function draw(){\n\n    var initialProps = {\n        dims: {\n          single: { width: 260, height: 225 },\n          double: { width: 540, height: 250}\n        },\n    };\n    \n    // Returns object with properties and methods representing\n    // dimensions, scales, axes, etc.\n    var werk = werkHelper.build(initialProps);\n    \n    \n    var line = d3.line()\n        .defined(function(d){ return !isNaN(d.y);})\n        .x(function(d) { return werk.scales.x(d.x); })\n        .y(function(d) { return werk.scales.y(d.y); });\n    \n    var svg = d3.select(\"#chart\")\n        .append(\"svg\")\n        .style(\"background-color\",\"transparent\")\n        .attr(\"width\", werk.dims.svg.width + werk.dims.margins.left + werk.dims.margins.right)\n        .attr(\"height\", werk.dims.svg.height + werk.dims.margins.top + werk.dims.margins.bottom)\n      .append(\"g\")\n        .attr(\"transform\", \"translate(\" + werk.dims.margins.left + \",\" + werk.dims.margins.top + \")\");\n\n    chartwerk.axes.base.shadedRegions.forEach(function(shade) {\n        var rectLeft = werk.scales.x(werk.parsers.base(shade.min));\n        var rectRight = werk.scales.x(werk.parsers.base(shade.max));\n        var minWidth = 2;\n        var width = Math.max(2, rectRight - rectLeft);\n        if (rectRight === rectLeft) {\n            svg.append('line')\n                .attr(\"class\",'solid-line')\n                .attr(\"y1\", 0)\n                .attr(\"y2\", werk.scales.y.range()[0])\n                .attr(\"x1\", rectLeft)\n                .attr(\"x2\", rectLeft);\n        } else {\n            svg.append('rect')\n                .attr(\"class\",\"shaded-area\")\n                .attr('y', 0)\n                .attr('x', rectLeft)\n                .attr('width', width)\n                .attr('height', werk.scales.y.range()[0]); \n        }\n    });\n    \n    chartwerk.axes.value.shadedRegions.forEach(function(shade) {\n        var rectMin = werk.scales.y(werk.parsers.value(shade.min));\n        var rectMax = werk.scales.y(werk.parsers.value(shade.max));\n        var height = Math.max(2, rectMin - rectMax);\n        if (rectMin === rectMax) {\n            svg.append('line')\n                .attr(\"class\",'dotted-line')\n                .attr(\"x1\", 0)\n                .attr(\"x2\", werk.scales.x.range()[1])\n                .attr(\"y1\", rectMin)\n                .attr(\"y2\", rectMin);\n        } else {\n            svg.append('rect')\n                .attr(\"class\",\"shaded-area\")\n                .attr('x', 0)\n                .attr('y', rectMax)\n                .attr('width', werk.scales.x.range()[1])\n                .attr('height', height); \n        }\n    });\n    \n\n    svg.append(\"g\")\n        .attr(\"class\", \"y axis\")\n        .call(werk.axes.y)\n      .append(\"text\")\n        .attr(\"class\",\"label\")\n        .attr(\"y\", -werk.dims.margins.top + 15)\n        .attr(\"x\", -werk.dims.margins.left)\n        .style(\"text-anchor\", \"start\")\n        .text(chartwerk.axes.value.label);\n    \n    svg.append(\"g\")\n        .attr(\"class\", \"x axis\")\n        .attr(\"transform\", \"translate(0,\" + werk.dims.svg.height + \")\")\n        .call(werk.axes.x);\n    \n    \n    var series = svg.selectAll(\".series\")\n        .data(werk.data)\n      .enter().append(\"g\")\n        .attr(\"class\",\"series\");\n    \n    series.append(\"path\")\n    \t\t.attr(\"class\",\"line\")\n    \t\t.attr(\"d\", function(d){ return line(d.values);})\n    \t\t.style(\"stroke\", function(d){ return werk.scales.color(d.name);});\n    \n    //A rect to catch mouse movements\n    var pointerRect = svg.append(\"rect\")\n    \t.attr(\"height\", werk.dims.svg.height)\n    \t.attr(\"width\", werk.dims.svg.width)\n    \t.style(\"fill\",\"none\")\n    \t.style(\"pointer-events\", \"fill\")\n        .on(\"mouseout\",  hideTooltip)\n        .on(\"mousemove\", showTooltip);\n    \n    \n    \n    var tooltip = d3.select(\"#chart\")\n      .append(\"div\")\n        .attr(\"class\",\"tooltip\")\n        .style(\"position\",\"absolute\");\n    tooltip\n      .append(\"div\")\n      .attr(\"class\",\"value\");\n    \n    var trackCirc = svg.append(\"circle\")\n\t\t.attr(\"cx\",0)\n\t\t.attr(\"cy\",0)\n\t\t.attr(\"r\",4)\n\t\t.style(\"fill\",\"none\")\n\t\t.style(\"stroke-width\",2)\n\t\t.style(\"display\",\"none\")\n        .style(\"pointer-events\", \"none\");\n      \n    function hideTooltip(){\n        d3.select(\".tooltip\")\n          .style(\"opacity\", 0);\n        trackCirc\n          .style(\"display\", \"none\");\n    }\n    \n    function showTooltip(){\n        var x0 = werk.scales.x.invert(d3.mouse(this)[0]),\n    \t\ty0 = werk.scales.y.invert(d3.mouse(this)[1]),\n    \n    \t\t//Start dist at a max number so we can check all distances less than\n    \t\tdist = werk.dataDims.xMax - werk.dataDims.xMin + werk.dataDims.yMax - werk.dataDims.yMin,\n    \t\tnearestX = 0,\n    \t\tnearestY = 0,\n    \t\tcolorGroup = \"\",\n    \t\tcomma = d3.format(\",\");\n    \n    \twerk.data.forEach(function(series){\n    \t\tseries.values.forEach(function(d){\n    \t\t\tif(Math.abs(x0 - d.x) + Math.abs(y0 - d.y)  < dist){\n    \t\t\t\tnearestX = d.x\n    \t\t\t\tnearestY = d.y\n    \t\t\t\tcolorGroup = series.name\n    \t\t\t\tdist = Math.abs(x0 - d.x) + Math.abs(y0 - d.y)\n    \t\t\t}\n    \t\t})\n    \n    \t});\n\n\n\t    trackCirc\n\t\t\t.attr(\"cx\", werk.scales.x(nearestX))\n\t\t\t.attr(\"cy\", werk.scales.y(nearestY))\n\t\t\t.style(\"stroke\",\"#333\")\n\t\t\t.style(\"display\",\"\");\n\t\t\n        d3.select(\".tooltip .value\")\n          .style(\"color\", werk.scales.color(colorGroup))\n          .text(function(){\n              var v = chartwerk.axes.value;\n              return v.prefix + comma(nearestY) + v.suffix;\n          });\n        var p = d3.mouse(this.parentElement.parentElement);\n        d3.select(\".tooltip\")\n            .style(\"opacity\", 1)\n            .style(\"top\", function(){\n                var s = chartwerk.ui.size,\n                    h = werk.dims[s].height,\n                    tipH = parseInt(d3.select(\".tooltip\").style(\"height\"), 10),\n                    pos = p[1] > (h / 2) ?\n                        p[1] - 60 : p[1] + 20;\n                return pos.toString() + \"px\";\n            })\n            .style(\"left\", function(){\n                // We position either left or right of the mouse point based\n                // on whether we're past the midpoint of the chart. This protects\n                // against tooltips overflowing embedded iframes.\n                var s = chartwerk.ui.size,\n                    w = werk.dims[s].width,\n                    tipW = parseInt(d3.select(\".tooltip\").style(\"width\"), 10),\n                    pos = p[0] > (w / 2) ?\n                        p[0] - (tipW + 20) : p[0] + 40;\n                return pos.toString() + \"px\";\n            });\n    }\n}", "styles": "#chartwerk {\n    font-family:'Gotham A', 'Gotham B', arial, sans-serif; \n    width:560px;\n}\n#chartwerk.single{\n    width:270px;\n    float:left;\n    overflow:hidden;\n    margin:10px 30px 10px 0;\n}\n#chartwerk #headline { \n    font-weight:bold;\n    font-size:24px;\n}\n#chartwerk #chatter {\n    margin-top:5px;\n}\n#chartwerk #footnote,\n#chartwerk #source,\n#chartwerk #author {\n    font-size:11px;\n    color:grey;\n\n}\n#chartwerk #author {\n    text-align:right;\n}\n#chartwerk #chart{\n    background-color:white;\n}\n#chartwerk #chart-legend \n.chart-legend-container .key-label{\n    font:11px 'Gotham A', 'Gotham B', arial, sans-serif;\n}\n#chartwerk #chart-legend \n.chart-legend-container .key-color{\n    margin-right:2px;\n}\n#chartwerk #chart-legend \n.chart-legend-container .key{\n    margin-right:8px;\n}\n#chartwerk .annotation p{\n    font-family:'Gotham A', 'Gotham B', arial, sans-serif;\n}\n#chartwerk #chart .tooltip{\n    font: 13px 'Gotham A', 'Gotham B', arial, sans-serif;\n    opacity:0;\n    pointer-events:none;\n    background:rgba(255,255,255,.75);\n    padding:5px;\n    width:auto;\n}\n#chartwerk #chart .tooltip .value{\n    font-weight: bold;\n}\n\n#chartwerk #chart path.line{\n    fill: none;\n    stroke-width: 2px;\n}\n\n.axis path,\n.axis line {\n  fill: none;\n  stroke: rgb(180,180,180);\n  shape-rendering: crispEdges;\n}\n.axis text{\n    font-family: 'Gotham A', 'Gotham B', 'Montserrat', arial, sans-serif;\n    fill: rgb(132,132,132);\n    font-size:11px;\n}\n.y.axis line{\n    stroke-dasharray: 3px 3px;\n}\n.y.axis path{\n    display:none;\n}\n.y.axis .label{\n    font-family: 'Gotham A', 'Gotham B', 'Montserrat', arial, sans-serif;\n    font-weight:normal;\n}\nline.dotted-line{\n    stroke:rgb(33,33,33);\n    stroke-width:1px;\n    stroke-dasharray: 7px 5px;\n}\nline.solid-line{\n    stroke:rgb(33,33,33);\n    stroke-width:1px;\n}\nrect.shaded-area{\n    fill:#ddd;\n}", "dependencies": {"styles": ["https://cloud.typography.com/6922714/7642152/css/fonts.css", "https://interactives.dallasnews.com/common/fonts/gotham.css"], "scripts": ["https://cdnjs.cloudflare.com/ajax/libs/d3/4.2.3/d3.min.js"]}, "html": "<div id='chart-header'>\n\t<h2 id='headline'></h2>\n\t<div id='chatter'></div> \n</div> \n<div id='chart-ui'>\n\t<!--You can put any necessary buttons, etc., here.-->\n</div>\n<div id='chart-legend'></div>\n<div id='chart'></div> \n<div id='chart-footer'> \n\t<div id='footnote'></div> \n\t<div id='source'></div> \n\t<div id='author'></div> \n</div>"}, "datamap": {"value": null, "custom": {}, "ignore": [], "scale": null, "series": ["CBM", "GQS"], "sort": [], "facet": null, "annotations": [], "base": "Date"}, "axes": {"color": {"ignoreScale": false, "domain": ["CBM", "GQS"], "byFacet": false, "quantizeProps": {"reverseColors": false, "groups": 0, "column": null}, "scheme": "categorical.default", "quantize": false, "range": ["#329CEB", "#E34E36"]}, "value": {"prefix": "$", "suffix": "", "min": null, "shadedRegions": [], "label": "Dollars", "max": null, "format": {"single": {"customTicks": [], "ticks": 7}, "double": {"customTicks": [], "ticks": 7}}}, "scale": {"prefix": "", "suffix": ""}, "base": {"prefix": "", "type": "date", "suffix": "", "min": null, "shadedRegions": [], "label": "", "max": null, "dateFormat": "%Y-%m-%d", "format": {"single": {"customTicks": [], "dateString": "Y", "ticks": 7, "frequency": 2}, "double": {"customTicks": [], "dateString": "Y", "ticks": 7, "frequency": 1}}}}, "ui": {"size": "double", "rawData": "Date\tCBM\tGQS\n2015-08-24\t45.47\t32.84\n2015-08-17\t45.14\t32.19\n2015-08-10\t49.05\t34.23\n2015-08-03\t50.32\t34.89\n2015-07-27\t49.25\t36.48\n2015-07-20\t48.91\t35.98\n2015-07-13\t49.04\t37.64\n2015-07-06\t45.61\t37.58\n2015-06-29\t44.24\t38.62\n2015-06-22\t43.99\t38.88\n2015-06-15\t44.77\t38.82\n2015-06-08\t43.39\t38.28\n2015-06-01\t42.69\t38.22\n2015-05-26\t40.02\t38.33\n2015-05-18\t40.91\t38.01\n2015-05-11\t39.00\t38.89\n2015-05-04\t38.71\t39.61\n2015-04-27\t37.28\t40.16\n2015-04-20\t42.97\t40.86\n2015-04-13\t40.98\t40.63\n2015-04-06\t43.21\t41.14\n2015-03-30\t40.61\t42.52\n2015-03-23\t34.93\t42.84\n2015-03-16\t36.69\t43.16\n2015-03-09\t35.98\t41.13\n2015-03-02\t33.77\t40.72\n2015-02-23\t34.25\t41.60\n2015-02-17\t33.56\t41.00\n2015-02-09\t32.96\t41.20\n2015-02-02\t30.01\t41.79\n2015-01-26\t22.43\t41.19\n2015-01-20\t22.77\t42.20\n2015-01-12\t22.36\t40.50\n2015-01-05\t22.13\t42.02\n2014-12-29\t21.58\t42.10\n2014-12-22\t21.79\t41.42\n2014-12-15\t23.00\t41.02\n2014-12-08\t23.66\t39.90\n2014-12-01\t23.51\t40.74\n2014-11-24\t22.75\t39.60\n2014-11-17\t22.74\t38.46\n2014-11-10\t23.17\t39.51\n2014-11-03\t22.66\t38.83\n2014-10-27\t21.08\t37.89\n2014-10-20\t18.07\t36.89\n2014-10-13\t17.40\t35.74\n2014-10-06\t18.47\t36.34\n2014-09-29\t17.19\t42.00\n2014-09-22\t19.05\t42.43\n2014-09-15\t20.81\t43.90\n2014-09-08\t22.46\t44.29\n2014-09-02\t22.35\t44.65\n2014-08-25\t21.92\t46.15\n2014-08-18\t21.46\t45.43\n2014-08-11\t21.50\t41.91\n2014-08-04\t21.77\t42.57\n2014-07-28\t22.60\t40.03\n2014-07-21\t22.08\t39.92\n2014-07-14\t20.51\t39.88\n2014-07-07\t21.70\t40.65\n2014-06-30\t21.82\t42.00\n2014-06-23\t20.41\t41.23\n2014-06-16\t21.00\t41.68\n2014-06-09\t20.35\t41.10\n2014-06-02\t21.58\t42.06\n2014-05-27\t21.49\t41.23\n2014-05-19\t20.90\t41.14\n2014-05-12\t19.48\t41.44\n2014-05-05\t17.99\t40.52\n2014-04-28\t19.23\t39.28\n2014-04-21\t20.67\t38.78\n2014-04-14\t21.04\t38.58\n2014-04-07\t19.67\t38.40\n2014-03-31\t19.97\t41.37\n2014-03-24\t18.18\t40.17\n2014-03-17\t18.94\t41.69\n2014-03-10\t19.43\t42.08\n2014-03-03\t20.90\t42.38\n2014-02-24\t20.07\t43.75\n2014-02-18\t21.77\t42.77\n2014-02-10\t21.19\t42.34\n2014-02-03\t21.05\t42.00\n2014-01-27\t18.77\t38.08\n2014-01-21\t16.51\t37.21\n2014-01-13\t17.55\t37.30\n2014-01-06\t18.64\t39.84\n2013-12-30\t17.20\t39.52\n2013-12-23\t17.62\t38.62\n2013-12-16\t17.93\t38.57\n2013-12-09\t18.39\t38.49\n2013-12-02\t18.90\t39.46\n2013-11-25\t19.50\t40.97\n2013-11-18\t19.34\t41.31\n2013-11-11\t18.84\t42.15\n2013-11-04\t19.14\t41.43\n2013-10-28\t17.26\t36.78\n2013-10-21\t16.81\t36.66\n2013-10-14\t16.54\t37.22\n2013-10-07\t14.76\t36.83\n2013-09-30\t13.44\t40.51\n2013-09-23\t13.09\t40.67\n2013-09-16\t13.20\t41.55\n2013-09-09\t13.16\t41.64\n2013-09-03\t12.76\t40.39\n2013-08-26\t13.63\t40.44\n2013-08-19\t14.10\t41.97\n2013-08-12\t14.33\t43.12\n2013-08-05\t14.21\t44.10\n2013-07-29\t14.40\t46.48\n2013-07-22\t14.87\t45.48\n2013-07-15\t15.33\t45.03\n2013-07-08\t15.28\t45.10\n2013-07-01\t14.40\t43.30\n2013-06-24\t13.97\t41.73\n2013-06-17\t14.33\t41.32\n2013-06-10\t13.92\t41.48\n2013-06-03\t13.57\t42.09\n2013-05-28\t13.76\t40.55\n2013-05-20\t12.63\t40.64\n2013-05-13\t13.16\t40.96\n2013-05-06\t12.87\t40.99\n2013-04-29\t12.30\t38.81\n2013-04-22\t12.62\t37.49\n2013-04-15\t12.56\t37.00\n2013-04-08\t12.81\t38.18\n2013-04-01\t12.05\t36.65\n2013-03-25\t12.79\t35.40\n2013-03-18\t12.52\t35.66\n2013-03-11\t12.20\t36.39\n2013-03-04\t12.32\t36.23\n2013-02-25\t11.87\t33.87\n2013-02-19\t11.92\t31.96\n2013-02-11\t11.89\t32.88\n2013-02-04\t12.53\t32.23\n2013-01-28\t12.08\t32.97\n2013-01-22\t11.53\t33.54\n2013-01-14\t11.27\t32.96\n2013-01-07\t11.77\t31.71\n2012-12-31\t11.54\t32.10\n2012-12-24\t11.30\t30.43\n2012-12-17\t11.35\t31.37\n2012-12-10\t11.38\t31.45\n2012-12-03\t11.06\t31.81\n2012-11-26\t10.97\t34.46\n2012-11-19\t9.64\t35.50\n2012-11-12\t9.34\t33.59\n2012-11-05\t9.66\t33.62\n2012-10-31\t11.65\t35.11\n2012-10-22\t12.16\t35.41\n2012-10-15\t12.95\t36.37\n2012-10-08\t13.06\t36.10\n2012-10-01\t13.04\t37.10\n2012-09-24\t11.73\t35.78\n2012-09-17\t13.01\t36.19\n2012-09-10\t12.64\t35.20\n2012-09-04\t12.46\t35.93\n2012-08-27\t12.18\t35.82\n2012-08-20\t12.40\t35.12\n2012-08-13\t12.49\t35.99\n2012-08-06\t10.93\t34.21\n2012-07-30\t10.95\t33.46\n2012-07-23\t9.67\t29.91\n2012-07-16\t9.49\t29.20\n2012-07-09\t9.50\t27.90\n2012-07-02\t10.07\t27.88\n2012-06-25\t9.41\t27.36\n2012-06-18\t8.30\t27.36\n2012-06-11\t7.54\t26.73\n2012-06-04\t7.20\t26.24\n2012-05-29\t7.08\t25.26\n2012-05-21\t7.08\t27.16\n2012-05-14\t6.78\t25.71\n2012-05-07\t6.86\t28.00\n2012-04-30\t6.87\t28.20\n2012-04-23\t6.72\t28.53\n2012-04-16\t6.37\t27.85\n2012-04-09\t6.21\t26.56\n2012-04-02\t6.75\t26.45\n2012-03-26\t6.99\t26.14\n2012-03-19\t6.69\t26.46\n2012-03-12\t6.70\t25.39\n2012-03-05\t6.88\t25.00\n2012-02-27\t6.55\t24.41\n2012-02-21\t7.52\t22.57\n2012-02-13\t7.55\t22.72\n2012-02-06\t7.08\t21.59\n2012-01-30\t8.24\t21.71\n2012-01-23\t7.97\t18.93\n2012-01-17\t7.58\t18.63\n2012-01-09\t7.52\t18.26\n2012-01-03\t7.90\t18.00\n2011-12-27\t7.18\t18.55\n2011-12-19\t7.40\t18.61\n2011-12-12\t7.61\t18.30\n2011-12-05\t7.38\t18.85\n2011-11-28\t7.10\t18.70\n2011-11-21\t6.21\t17.62\n2011-11-14\t6.29\t18.76\n2011-11-07\t6.00\t20.33\n2011-10-31\t5.63\t19.65\n2011-10-24\t5.66\t19.33\n2011-10-17\t5.46\t18.71\n2011-10-10\t5.52\t17.78\n2011-10-03\t4.90\t17.30\n2011-09-26\t5.04\t16.24\n2011-09-19\t4.80\t16.31\n2011-09-12\t5.35\t17.04\n2011-09-06\t4.86\t16.00\n2011-08-29\t4.70\t15.60\n2011-08-22\t4.54\t16.28\n2011-08-15\t4.31\t15.69\n2011-08-08\t4.81\t16.49\n2011-08-01\t4.80\t16.75\n2011-07-25\t4.41\t19.29\n2011-07-18\t4.94\t19.66\n2011-07-11\t5.09\t18.91\n2011-07-05\t4.93\t18.98\n2011-06-27\t4.76\t18.28\n2011-06-20\t4.29\t17.66\n2011-06-13\t4.07\t17.83\n2011-06-06\t4.24\t17.72\n2011-05-31\t4.47\t17.92\n2011-05-23\t4.82\t19.20\n2011-05-16\t4.78\t19.22\n2011-05-09\t5.04\t23.05\n2011-05-02\t4.60\t22.60\n2011-04-25\t5.26\t23.24\n2011-04-18\t5.01\t21.99\n2011-04-11\t5.04\t22.47\n2011-04-04\t5.05\t22.25\n2011-03-28\t5.50\t22.63\n2011-03-21\t5.36\t22.56\n2011-03-14\t4.61\t21.87\n2011-03-07\t5.05\t21.97\n2011-02-28\t5.43\t21.59\n2011-02-22\t5.54\t22.75\n2011-02-14\t5.61\t23.05\n2011-02-07\t5.95\t21.40\n2011-01-31\t4.94\t20.10\n2011-01-24\t4.71\t19.20\n2011-01-18\t4.88\t20.10\n2011-01-10\t5.23\t20.41\n2011-01-03\t5.01\t20.51\n2010-12-27\t5.17\t22.14\n2010-12-20\t5.92\t21.46\n2010-12-13\t5.85\t21.19\n2010-12-06\t4.98\t21.48\n2010-11-29\t4.33\t21.44\n2010-11-22\t4.20\t20.90\n2010-11-15\t4.31\t20.70\n2010-11-08\t4.25\t20.49\n2010-11-01\t4.27\t20.81\n2010-10-25\t4.53\t19.01\n2010-10-18\t4.44\t19.15\n2010-10-11\t4.74\t19.52\n2010-10-04\t4.17\t18.21\n2010-09-27\t4.10\t18.51\n2010-09-20\t4.41\t18.83\n2010-09-13\t4.01\t18.91\n2010-09-07\t4.12\t17.37\n2010-08-30\t4.30\t17.65\n2010-08-23\t4.06\t17.03\n2010-08-16\t4.36\t17.32\n2010-08-09\t3.80\t17.67\n2010-08-02\t3.97\t18.28\n2010-07-26\t3.55\t18.11\n2010-07-19\t3.50\t18.41\n2010-07-12\t3.11\t18.13\n2010-07-06\t3.11\t18.53\n2010-06-28\t2.98\t19.48\n2010-06-21\t3.40\t20.20\n2010-06-14\t3.75\t21.24\n2010-06-07\t3.71\t21.99\n2010-06-01\t3.78\t20.96\n2010-05-24\t4.17\t21.80\n2010-05-17\t4.36\t22.15\n2010-05-10\t4.46\t22.96\n2010-05-03\t4.25\t22.27\n2010-04-26\t4.39\t24.73\n2010-04-19\t4.30\t26.06\n2010-04-12\t4.42\t25.00\n2010-04-05\t4.37\t24.85\n2010-03-29\t4.11\t23.63\n2010-03-22\t3.88\t23.42\n2010-03-15\t4.25\t23.22\n2010-03-08\t4.23\t22.80\n2010-03-01\t4.24\t22.32\n2010-02-22\t3.77\t21.50\n2010-02-16\t4.11\t19.85\n2010-02-08\t4.31\t19.95\n2010-02-01\t5.19\t19.88\n2010-01-25\t5.38\t19.08\n2010-01-19\t5.74\t18.86\n2010-01-11\t5.83\t19.56\n2010-01-04\t5.68\t20.40\n2009-12-28\t5.58\t20.95\n2009-12-21\t5.69\t20.71\n2009-12-14\t5.43\t20.89\n2009-12-07\t5.35\t21.46\n2009-11-30\t5.48\t21.77\n2009-11-23\t5.70\t22.03\n2009-11-16\t5.86\t21.95\n2009-11-09\t6.15\t22.42\n2009-11-02\t6.27\t23.03\n2009-10-26\t6.00\t21.34\n2009-10-19\t6.78\t22.02\n2009-10-12\t6.95\t22.96\n2009-10-05\t6.77\t22.24\n2009-09-28\t6.12\t20.81\n2009-09-21\t6.15\t21.48\n2009-09-14\t6.43\t22.02\n2009-09-08\t6.06\t21.60\n2009-08-31\t5.72\t21.12\n2009-08-24\t5.52\t19.93\n2009-08-17\t5.36\t19.48\n2009-08-10\t4.66\t18.78\n2009-08-03\t4.58\t18.58\n2009-07-27\t4.58\t16.32\n2009-07-20\t4.46\t15.94\n2009-07-13\t4.40\t16.17\n2009-07-06\t4.10\t14.96\n2009-06-29\t4.05\t15.39\n2009-06-22\t4.48\t16.06\n2009-06-15\t4.20\t15.80\n2009-06-08\t4.00\t16.37\n2009-06-01\t4.10\t16.63\n2009-05-26\t3.60\t17.85\n2009-05-18\t3.91\t16.39\n2009-05-11\t3.71\t15.16\n2009-05-04\t4.00\t16.55\n2009-04-27\t2.45\t15.77\n2009-04-20\t2.58\t15.28\n2009-04-13\t2.78\t15.12\n2009-04-06\t2.84\t15.09\n2009-03-30\t2.30\t15.25\n2009-03-23\t2.48\t13.06\n2009-03-16\t2.49\t11.98\n2009-03-09\t1.75\t11.99\n2009-03-02\t1.50\t9.85\n2009-02-23\t2.16\t10.79\n2009-02-17\t3.30\t11.55\n2009-02-09\t3.98\t11.62\n2009-02-02\t4.62\t11.94\n2009-01-26\t3.27\t11.28\n2009-01-20\t3.50\t12.00\n2009-01-12\t4.30\t12.14\n2009-01-05\t4.45\t12.99\n2008-12-29\t4.35\t14.07\n2008-12-22\t4.52\t12.97\n2008-12-15\t4.63\t13.57\n2008-12-08\t3.86\t13.19\n2008-12-01\t3.69\t14.01\n2008-11-24\t3.48\t13.02\n2008-11-17\t2.50\t12.10\n2008-11-10\t2.94\t11.55\n2008-11-03\t3.88\t12.82\n2008-10-27\t4.50\t12.94\n2008-10-20\t4.59\t11.21\n2008-10-13\t4.98\t13.42\n2008-10-06\t4.36\t13.82\n2008-09-29\t4.59\t16.83\n2008-09-22\t6.38\t18.37\n2008-09-15\t6.60\t19.08\n2008-09-08\t6.48\t19.37\n2008-09-02\t6.24\t19.19\n2008-08-25\t6.51\t19.45\n2008-08-18\t6.73\t19.88\n2008-08-11\t6.74\t19.40\n2008-08-04\t6.60\t18.09\n2008-07-28\t7.69\t16.34\n2008-07-21\t7.89\t16.29\n2008-07-14\t6.83\t16.60\n2008-07-07\t6.03\t15.25\n2008-06-30\t5.45\t16.45\n2008-06-23\t5.98\t16.74\n2008-06-16\t6.48\t17.45\n2008-06-09\t6.32\t18.00\n2008-06-02\t6.35\t17.17\n2008-05-27\t6.15\t18.25\n2008-05-19\t5.59\t17.94\n2008-05-12\t5.99\t18.43\n2008-05-05\t5.51\t17.94\n2008-04-28\t5.96\t18.68\n2008-04-21\t5.97\t19.34\n2008-04-14\t5.95\t19.00\n2008-04-07\t6.20\t17.95\n2008-03-31\t7.09\t19.05\n2008-03-24\t6.94\t19.52\n2008-03-17\t8.01\t21.37\n2008-03-10\t7.83\t19.81\n2008-03-03\t7.94\t19.58\n2008-02-25\t8.73\t20.17\n2008-02-19\t9.48\t19.71\n2008-02-11\t9.84\t19.70\n2008-02-04\t10.46\t19.78\n2008-01-28\t9.73\t19.34\n2008-01-22\t9.32\t17.80\n2008-01-14\t9.76\t17.23\n2008-01-07\t8.57\t17.20\n2007-12-31\t7.80\t19.66\n2007-12-24\t8.36\t21.36\n2007-12-17\t9.03\t21.76\n2007-12-10\t8.50\t21.18\n2007-12-03\t8.24\t21.57\n2007-11-26\t7.74\t20.40\n2007-11-19\t7.71\t18.89\n2007-11-12\t7.97\t20.09\n2007-11-05\t9.17\t19.38\n2007-10-29\t10.52\t18.21\n2007-10-22\t11.37\t18.61\n2007-10-15\t10.67\t17.75\n2007-10-08\t11.45\t19.01\n2007-10-01\t10.88\t18.91\n2007-09-24\t10.89\t18.44\n2007-09-17\t12.06\t18.55\n2007-09-10\t11.33\t18.00\n2007-09-04\t11.42\t17.94\n2007-08-27\t12.47\t18.76\n2007-08-20\t12.83\t18.51\n2007-08-13\t13.38\t17.27\n2007-08-06\t11.81\t16.75\n2007-07-30\t12.96\t16.44\n2007-07-23\t13.30\t17.79\n2007-07-16\t13.69\t18.63\n2007-07-09\t14.35\t18.56\n2007-07-02\t13.58\t19.22\n2007-06-25\t13.27\t19.10\n2007-06-18\t13.45\t19.34\n2007-06-11\t13.40\t18.97\n2007-06-04\t12.69\t18.47\n2007-05-29\t12.53\t18.51\n2007-05-21\t12.53\t18.18\n2007-05-14\t12.53\t18.44\n2007-05-07\t12.13\t18.32\n2007-04-30\t11.67\t18.50\n2007-04-23\t24.56\t18.31\n2007-04-16\t25.04\t18.96\n2007-04-09\t25.45\t18.47\n2007-04-02\t24.97\t17.64\n2007-03-26\t24.60\t17.21\n2007-03-19\t24.84\t17.85\n2007-03-12\t24.50\t17.50\n2007-03-05\t23.13\t17.84\n2007-02-26\t22.67\t18.40\n2007-02-20\t23.49\t19.81\n2007-02-12\t23.50\t20.02\n2007-02-05\t23.38\t19.55\n2007-01-29\t21.92\t19.47\n2007-01-22\t21.46\t19.04\n2007-01-16\t22.05\t20.00\n2007-01-08\t22.33\t20.30\n2007-01-03\t22.37\t18.89\n2006-12-26\t22.72\t19.50\n2006-12-18\t22.88\t19.95\n2006-12-11\t22.39\t20.39\n2006-12-04\t22.60\t19.66\n2006-11-27\t22.12\t18.68\n2006-11-20\t22.31\t19.30\n2006-11-13\t22.39\t19.81\n2006-11-06\t22.66\t20.19\n2006-10-30\t22.67\t19.57\n2006-10-23\t23.88\t20.72\n2006-10-16\t21.53\t19.30\n2006-10-09\t21.59\t19.85\n2006-10-02\t21.37\t19.07\n2006-09-25\t20.71\t18.95\n2006-09-18\t21.05\t18.39\n2006-09-11\t21.70\t17.92\n2006-09-05\t21.18\t16.90\n2006-08-28\t22.76\t16.90\n2006-08-21\t21.52\t16.61\n2006-08-14\t21.13\t16.65\n2006-08-07\t19.78\t16.90\n2006-07-31\t20.94\t16.75\n2006-07-24\t21.59\t17.12\n", "datamap": [{"available": true, "class": "base", "alias": "X axis"}, {"available": false, "class": "value", "alias": "value axis"}, {"available": false, "class": "scale", "alias": "scale axis"}, {"available": true, "class": "series", "alias": "Y axis"}, {"available": false, "class": "facet", "alias": "faceting column"}, {"available": false, "class": "ignore", "alias": "ignored column"}]}, "margins": {"single": {"left": 0.11, "top": 0.05, "right": 0.020000000000000018, "bottom": 0.10999999999999999}, "double": {"left": 0.06, "top": 0.05, "right": 0.020000000000000018, "bottom": 0.07999999999999996}}, "data": [{"GQS": 32.84, "Date": "2015-08-24", "CBM": 45.47}, {"GQS": 32.19, "Date": "2015-08-17", "CBM": 45.14}, {"GQS": 34.23, "Date": "2015-08-10", "CBM": 49.05}, {"GQS": 34.89, "Date": "2015-08-03", "CBM": 50.32}, {"GQS": 36.48, "Date": "2015-07-27", "CBM": 49.25}, {"GQS": 35.98, "Date": "2015-07-20", "CBM": 48.91}, {"GQS": 37.64, "Date": "2015-07-13", "CBM": 49.04}, {"GQS": 37.58, "Date": "2015-07-06", "CBM": 45.61}, {"GQS": 38.62, "Date": "2015-06-29", "CBM": 44.24}, {"GQS": 38.88, "Date": "2015-06-22", "CBM": 43.99}, {"GQS": 38.82, "Date": "2015-06-15", "CBM": 44.77}, {"GQS": 38.28, "Date": "2015-06-08", "CBM": 43.39}, {"GQS": 38.22, "Date": "2015-06-01", "CBM": 42.69}, {"GQS": 38.33, "Date": "2015-05-26", "CBM": 40.02}, {"GQS": 38.01, "Date": "2015-05-18", "CBM": 40.91}, {"GQS": 38.89, "Date": "2015-05-11", "CBM": 39}, {"GQS": 39.61, "Date": "2015-05-04", "CBM": 38.71}, {"GQS": 40.16, "Date": "2015-04-27", "CBM": 37.28}, {"GQS": 40.86, "Date": "2015-04-20", "CBM": 42.97}, {"GQS": 40.63, "Date": "2015-04-13", "CBM": 40.98}, {"GQS": 41.14, "Date": "2015-04-06", "CBM": 43.21}, {"GQS": 42.52, "Date": "2015-03-30", "CBM": 40.61}, {"GQS": 42.84, "Date": "2015-03-23", "CBM": 34.93}, {"GQS": 43.16, "Date": "2015-03-16", "CBM": 36.69}, {"GQS": 41.13, "Date": "2015-03-09", "CBM": 35.98}, {"GQS": 40.72, "Date": "2015-03-02", "CBM": 33.77}, {"GQS": 41.6, "Date": "2015-02-23", "CBM": 34.25}, {"GQS": 41, "Date": "2015-02-17", "CBM": 33.56}, {"GQS": 41.2, "Date": "2015-02-09", "CBM": 32.96}, {"GQS": 41.79, "Date": "2015-02-02", "CBM": 30.01}, {"GQS": 41.19, "Date": "2015-01-26", "CBM": 22.43}, {"GQS": 42.2, "Date": "2015-01-20", "CBM": 22.77}, {"GQS": 40.5, "Date": "2015-01-12", "CBM": 22.36}, {"GQS": 42.02, "Date": "2015-01-05", "CBM": 22.13}, {"GQS": 42.1, "Date": "2014-12-29", "CBM": 21.58}, {"GQS": 41.42, "Date": "2014-12-22", "CBM": 21.79}, {"GQS": 41.02, "Date": "2014-12-15", "CBM": 23}, {"GQS": 39.9, "Date": "2014-12-08", "CBM": 23.66}, {"GQS": 40.74, "Date": "2014-12-01", "CBM": 23.51}, {"GQS": 39.6, "Date": "2014-11-24", "CBM": 22.75}, {"GQS": 38.46, "Date": "2014-11-17", "CBM": 22.74}, {"GQS": 39.51, "Date": "2014-11-10", "CBM": 23.17}, {"GQS": 38.83, "Date": "2014-11-03", "CBM": 22.66}, {"GQS": 37.89, "Date": "2014-10-27", "CBM": 21.08}, {"GQS": 36.89, "Date": "2014-10-20", "CBM": 18.07}, {"GQS": 35.74, "Date": "2014-10-13", "CBM": 17.4}, {"GQS": 36.34, "Date": "2014-10-06", "CBM": 18.47}, {"GQS": 42, "Date": "2014-09-29", "CBM": 17.19}, {"GQS": 42.43, "Date": "2014-09-22", "CBM": 19.05}, {"GQS": 43.9, "Date": "2014-09-15", "CBM": 20.81}, {"GQS": 44.29, "Date": "2014-09-08", "CBM": 22.46}, {"GQS": 44.65, "Date": "2014-09-02", "CBM": 22.35}, {"GQS": 46.15, "Date": "2014-08-25", "CBM": 21.92}, {"GQS": 45.43, "Date": "2014-08-18", "CBM": 21.46}, {"GQS": 41.91, "Date": "2014-08-11", "CBM": 21.5}, {"GQS": 42.57, "Date": "2014-08-04", "CBM": 21.77}, {"GQS": 40.03, "Date": "2014-07-28", "CBM": 22.6}, {"GQS": 39.92, "Date": "2014-07-21", "CBM": 22.08}, {"GQS": 39.88, "Date": "2014-07-14", "CBM": 20.51}, {"GQS": 40.65, "Date": "2014-07-07", "CBM": 21.7}, {"GQS": 42, "Date": "2014-06-30", "CBM": 21.82}, {"GQS": 41.23, "Date": "2014-06-23", "CBM": 20.41}, {"GQS": 41.68, "Date": "2014-06-16", "CBM": 21}, {"GQS": 41.1, "Date": "2014-06-09", "CBM": 20.35}, {"GQS": 42.06, "Date": "2014-06-02", "CBM": 21.58}, {"GQS": 41.23, "Date": "2014-05-27", "CBM": 21.49}, {"GQS": 41.14, "Date": "2014-05-19", "CBM": 20.9}, {"GQS": 41.44, "Date": "2014-05-12", "CBM": 19.48}, {"GQS": 40.52, "Date": "2014-05-05", "CBM": 17.99}, {"GQS": 39.28, "Date": "2014-04-28", "CBM": 19.23}, {"GQS": 38.78, "Date": "2014-04-21", "CBM": 20.67}, {"GQS": 38.58, "Date": "2014-04-14", "CBM": 21.04}, {"GQS": 38.4, "Date": "2014-04-07", "CBM": 19.67}, {"GQS": 41.37, "Date": "2014-03-31", "CBM": 19.97}, {"GQS": 40.17, "Date": "2014-03-24", "CBM": 18.18}, {"GQS": 41.69, "Date": "2014-03-17", "CBM": 18.94}, {"GQS": 42.08, "Date": "2014-03-10", "CBM": 19.43}, {"GQS": 42.38, "Date": "2014-03-03", "CBM": 20.9}, {"GQS": 43.75, "Date": "2014-02-24", "CBM": 20.07}, {"GQS": 42.77, "Date": "2014-02-18", "CBM": 21.77}, {"GQS": 42.34, "Date": "2014-02-10", "CBM": 21.19}, {"GQS": 42, "Date": "2014-02-03", "CBM": 21.05}, {"GQS": 38.08, "Date": "2014-01-27", "CBM": 18.77}, {"GQS": 37.21, "Date": "2014-01-21", "CBM": 16.51}, {"GQS": 37.3, "Date": "2014-01-13", "CBM": 17.55}, {"GQS": 39.84, "Date": "2014-01-06", "CBM": 18.64}, {"GQS": 39.52, "Date": "2013-12-30", "CBM": 17.2}, {"GQS": 38.62, "Date": "2013-12-23", "CBM": 17.62}, {"GQS": 38.57, "Date": "2013-12-16", "CBM": 17.93}, {"GQS": 38.49, "Date": "2013-12-09", "CBM": 18.39}, {"GQS": 39.46, "Date": "2013-12-02", "CBM": 18.9}, {"GQS": 40.97, "Date": "2013-11-25", "CBM": 19.5}, {"GQS": 41.31, "Date": "2013-11-18", "CBM": 19.34}, {"GQS": 42.15, "Date": "2013-11-11", "CBM": 18.84}, {"GQS": 41.43, "Date": "2013-11-04", "CBM": 19.14}, {"GQS": 36.78, "Date": "2013-10-28", "CBM": 17.26}, {"GQS": 36.66, "Date": "2013-10-21", "CBM": 16.81}, {"GQS": 37.22, "Date": "2013-10-14", "CBM": 16.54}, {"GQS": 36.83, "Date": "2013-10-07", "CBM": 14.76}, {"GQS": 40.51, "Date": "2013-09-30", "CBM": 13.44}, {"GQS": 40.67, "Date": "2013-09-23", "CBM": 13.09}, {"GQS": 41.55, "Date": "2013-09-16", "CBM": 13.2}, {"GQS": 41.64, "Date": "2013-09-09", "CBM": 13.16}, {"GQS": 40.39, "Date": "2013-09-03", "CBM": 12.76}, {"GQS": 40.44, "Date": "2013-08-26", "CBM": 13.63}, {"GQS": 41.97, "Date": "2013-08-19", "CBM": 14.1}, {"GQS": 43.12, "Date": "2013-08-12", "CBM": 14.33}, {"GQS": 44.1, "Date": "2013-08-05", "CBM": 14.21}, {"GQS": 46.48, "Date": "2013-07-29", "CBM": 14.4}, {"GQS": 45.48, "Date": "2013-07-22", "CBM": 14.87}, {"GQS": 45.03, "Date": "2013-07-15", "CBM": 15.33}, {"GQS": 45.1, "Date": "2013-07-08", "CBM": 15.28}, {"GQS": 43.3, "Date": "2013-07-01", "CBM": 14.4}, {"GQS": 41.73, "Date": "2013-06-24", "CBM": 13.97}, {"GQS": 41.32, "Date": "2013-06-17", "CBM": 14.33}, {"GQS": 41.48, "Date": "2013-06-10", "CBM": 13.92}, {"GQS": 42.09, "Date": "2013-06-03", "CBM": 13.57}, {"GQS": 40.55, "Date": "2013-05-28", "CBM": 13.76}, {"GQS": 40.64, "Date": "2013-05-20", "CBM": 12.63}, {"GQS": 40.96, "Date": "2013-05-13", "CBM": 13.16}, {"GQS": 40.99, "Date": "2013-05-06", "CBM": 12.87}, {"GQS": 38.81, "Date": "2013-04-29", "CBM": 12.3}, {"GQS": 37.49, "Date": "2013-04-22", "CBM": 12.62}, {"GQS": 37, "Date": "2013-04-15", "CBM": 12.56}, {"GQS": 38.18, "Date": "2013-04-08", "CBM": 12.81}, {"GQS": 36.65, "Date": "2013-04-01", "CBM": 12.05}, {"GQS": 35.4, "Date": "2013-03-25", "CBM": 12.79}, {"GQS": 35.66, "Date": "2013-03-18", "CBM": 12.52}, {"GQS": 36.39, "Date": "2013-03-11", "CBM": 12.2}, {"GQS": 36.23, "Date": "2013-03-04", "CBM": 12.32}, {"GQS": 33.87, "Date": "2013-02-25", "CBM": 11.87}, {"GQS": 31.96, "Date": "2013-02-19", "CBM": 11.92}, {"GQS": 32.88, "Date": "2013-02-11", "CBM": 11.89}, {"GQS": 32.23, "Date": "2013-02-04", "CBM": 12.53}, {"GQS": 32.97, "Date": "2013-01-28", "CBM": 12.08}, {"GQS": 33.54, "Date": "2013-01-22", "CBM": 11.53}, {"GQS": 32.96, "Date": "2013-01-14", "CBM": 11.27}, {"GQS": 31.71, "Date": "2013-01-07", "CBM": 11.77}, {"GQS": 32.1, "Date": "2012-12-31", "CBM": 11.54}, {"GQS": 30.43, "Date": "2012-12-24", "CBM": 11.3}, {"GQS": 31.37, "Date": "2012-12-17", "CBM": 11.35}, {"GQS": 31.45, "Date": "2012-12-10", "CBM": 11.38}, {"GQS": 31.81, "Date": "2012-12-03", "CBM": 11.06}, {"GQS": 34.46, "Date": "2012-11-26", "CBM": 10.97}, {"GQS": 35.5, "Date": "2012-11-19", "CBM": 9.64}, {"GQS": 33.59, "Date": "2012-11-12", "CBM": 9.34}, {"GQS": 33.62, "Date": "2012-11-05", "CBM": 9.66}, {"GQS": 35.11, "Date": "2012-10-31", "CBM": 11.65}, {"GQS": 35.41, "Date": "2012-10-22", "CBM": 12.16}, {"GQS": 36.37, "Date": "2012-10-15", "CBM": 12.95}, {"GQS": 36.1, "Date": "2012-10-08", "CBM": 13.06}, {"GQS": 37.1, "Date": "2012-10-01", "CBM": 13.04}, {"GQS": 35.78, "Date": "2012-09-24", "CBM": 11.73}, {"GQS": 36.19, "Date": "2012-09-17", "CBM": 13.01}, {"GQS": 35.2, "Date": "2012-09-10", "CBM": 12.64}, {"GQS": 35.93, "Date": "2012-09-04", "CBM": 12.46}, {"GQS": 35.82, "Date": "2012-08-27", "CBM": 12.18}, {"GQS": 35.12, "Date": "2012-08-20", "CBM": 12.4}, {"GQS": 35.99, "Date": "2012-08-13", "CBM": 12.49}, {"GQS": 34.21, "Date": "2012-08-06", "CBM": 10.93}, {"GQS": 33.46, "Date": "2012-07-30", "CBM": 10.95}, {"GQS": 29.91, "Date": "2012-07-23", "CBM": 9.67}, {"GQS": 29.2, "Date": "2012-07-16", "CBM": 9.49}, {"GQS": 27.9, "Date": "2012-07-09", "CBM": 9.5}, {"GQS": 27.88, "Date": "2012-07-02", "CBM": 10.07}, {"GQS": 27.36, "Date": "2012-06-25", "CBM": 9.41}, {"GQS": 27.36, "Date": "2012-06-18", "CBM": 8.3}, {"GQS": 26.73, "Date": "2012-06-11", "CBM": 7.54}, {"GQS": 26.24, "Date": "2012-06-04", "CBM": 7.2}, {"GQS": 25.26, "Date": "2012-05-29", "CBM": 7.08}, {"GQS": 27.16, "Date": "2012-05-21", "CBM": 7.08}, {"GQS": 25.71, "Date": "2012-05-14", "CBM": 6.78}, {"GQS": 28, "Date": "2012-05-07", "CBM": 6.86}, {"GQS": 28.2, "Date": "2012-04-30", "CBM": 6.87}, {"GQS": 28.53, "Date": "2012-04-23", "CBM": 6.72}, {"GQS": 27.85, "Date": "2012-04-16", "CBM": 6.37}, {"GQS": 26.56, "Date": "2012-04-09", "CBM": 6.21}, {"GQS": 26.45, "Date": "2012-04-02", "CBM": 6.75}, {"GQS": 26.14, "Date": "2012-03-26", "CBM": 6.99}, {"GQS": 26.46, "Date": "2012-03-19", "CBM": 6.69}, {"GQS": 25.39, "Date": "2012-03-12", "CBM": 6.7}, {"GQS": 25, "Date": "2012-03-05", "CBM": 6.88}, {"GQS": 24.41, "Date": "2012-02-27", "CBM": 6.55}, {"GQS": 22.57, "Date": "2012-02-21", "CBM": 7.52}, {"GQS": 22.72, "Date": "2012-02-13", "CBM": 7.55}, {"GQS": 21.59, "Date": "2012-02-06", "CBM": 7.08}, {"GQS": 21.71, "Date": "2012-01-30", "CBM": 8.24}, {"GQS": 18.93, "Date": "2012-01-23", "CBM": 7.97}, {"GQS": 18.63, "Date": "2012-01-17", "CBM": 7.58}, {"GQS": 18.26, "Date": "2012-01-09", "CBM": 7.52}, {"GQS": 18, "Date": "2012-01-03", "CBM": 7.9}, {"GQS": 18.55, "Date": "2011-12-27", "CBM": 7.18}, {"GQS": 18.61, "Date": "2011-12-19", "CBM": 7.4}, {"GQS": 18.3, "Date": "2011-12-12", "CBM": 7.61}, {"GQS": 18.85, "Date": "2011-12-05", "CBM": 7.38}, {"GQS": 18.7, "Date": "2011-11-28", "CBM": 7.1}, {"GQS": 17.62, "Date": "2011-11-21", "CBM": 6.21}, {"GQS": 18.76, "Date": "2011-11-14", "CBM": 6.29}, {"GQS": 20.33, "Date": "2011-11-07", "CBM": 6}, {"GQS": 19.65, "Date": "2011-10-31", "CBM": 5.63}, {"GQS": 19.33, "Date": "2011-10-24", "CBM": 5.66}, {"GQS": 18.71, "Date": "2011-10-17", "CBM": 5.46}, {"GQS": 17.78, "Date": "2011-10-10", "CBM": 5.52}, {"GQS": 17.3, "Date": "2011-10-03", "CBM": 4.9}, {"GQS": 16.24, "Date": "2011-09-26", "CBM": 5.04}, {"GQS": 16.31, "Date": "2011-09-19", "CBM": 4.8}, {"GQS": 17.04, "Date": "2011-09-12", "CBM": 5.35}, {"GQS": 16, "Date": "2011-09-06", "CBM": 4.86}, {"GQS": 15.6, "Date": "2011-08-29", "CBM": 4.7}, {"GQS": 16.28, "Date": "2011-08-22", "CBM": 4.54}, {"GQS": 15.69, "Date": "2011-08-15", "CBM": 4.31}, {"GQS": 16.49, "Date": "2011-08-08", "CBM": 4.81}, {"GQS": 16.75, "Date": "2011-08-01", "CBM": 4.8}, {"GQS": 19.29, "Date": "2011-07-25", "CBM": 4.41}, {"GQS": 19.66, "Date": "2011-07-18", "CBM": 4.94}, {"GQS": 18.91, "Date": "2011-07-11", "CBM": 5.09}, {"GQS": 18.98, "Date": "2011-07-05", "CBM": 4.93}, {"GQS": 18.28, "Date": "2011-06-27", "CBM": 4.76}, {"GQS": 17.66, "Date": "2011-06-20", "CBM": 4.29}, {"GQS": 17.83, "Date": "2011-06-13", "CBM": 4.07}, {"GQS": 17.72, "Date": "2011-06-06", "CBM": 4.24}, {"GQS": 17.92, "Date": "2011-05-31", "CBM": 4.47}, {"GQS": 19.2, "Date": "2011-05-23", "CBM": 4.82}, {"GQS": 19.22, "Date": "2011-05-16", "CBM": 4.78}, {"GQS": 23.05, "Date": "2011-05-09", "CBM": 5.04}, {"GQS": 22.6, "Date": "2011-05-02", "CBM": 4.6}, {"GQS": 23.24, "Date": "2011-04-25", "CBM": 5.26}, {"GQS": 21.99, "Date": "2011-04-18", "CBM": 5.01}, {"GQS": 22.47, "Date": "2011-04-11", "CBM": 5.04}, {"GQS": 22.25, "Date": "2011-04-04", "CBM": 5.05}, {"GQS": 22.63, "Date": "2011-03-28", "CBM": 5.5}, {"GQS": 22.56, "Date": "2011-03-21", "CBM": 5.36}, {"GQS": 21.87, "Date": "2011-03-14", "CBM": 4.61}, {"GQS": 21.97, "Date": "2011-03-07", "CBM": 5.05}, {"GQS": 21.59, "Date": "2011-02-28", "CBM": 5.43}, {"GQS": 22.75, "Date": "2011-02-22", "CBM": 5.54}, {"GQS": 23.05, "Date": "2011-02-14", "CBM": 5.61}, {"GQS": 21.4, "Date": "2011-02-07", "CBM": 5.95}, {"GQS": 20.1, "Date": "2011-01-31", "CBM": 4.94}, {"GQS": 19.2, "Date": "2011-01-24", "CBM": 4.71}, {"GQS": 20.1, "Date": "2011-01-18", "CBM": 4.88}, {"GQS": 20.41, "Date": "2011-01-10", "CBM": 5.23}, {"GQS": 20.51, "Date": "2011-01-03", "CBM": 5.01}, {"GQS": 22.14, "Date": "2010-12-27", "CBM": 5.17}, {"GQS": 21.46, "Date": "2010-12-20", "CBM": 5.92}, {"GQS": 21.19, "Date": "2010-12-13", "CBM": 5.85}, {"GQS": 21.48, "Date": "2010-12-06", "CBM": 4.98}, {"GQS": 21.44, "Date": "2010-11-29", "CBM": 4.33}, {"GQS": 20.9, "Date": "2010-11-22", "CBM": 4.2}, {"GQS": 20.7, "Date": "2010-11-15", "CBM": 4.31}, {"GQS": 20.49, "Date": "2010-11-08", "CBM": 4.25}, {"GQS": 20.81, "Date": "2010-11-01", "CBM": 4.27}, {"GQS": 19.01, "Date": "2010-10-25", "CBM": 4.53}, {"GQS": 19.15, "Date": "2010-10-18", "CBM": 4.44}, {"GQS": 19.52, "Date": "2010-10-11", "CBM": 4.74}, {"GQS": 18.21, "Date": "2010-10-04", "CBM": 4.17}, {"GQS": 18.51, "Date": "2010-09-27", "CBM": 4.1}, {"GQS": 18.83, "Date": "2010-09-20", "CBM": 4.41}, {"GQS": 18.91, "Date": "2010-09-13", "CBM": 4.01}, {"GQS": 17.37, "Date": "2010-09-07", "CBM": 4.12}, {"GQS": 17.65, "Date": "2010-08-30", "CBM": 4.3}, {"GQS": 17.03, "Date": "2010-08-23", "CBM": 4.06}, {"GQS": 17.32, "Date": "2010-08-16", "CBM": 4.36}, {"GQS": 17.67, "Date": "2010-08-09", "CBM": 3.8}, {"GQS": 18.28, "Date": "2010-08-02", "CBM": 3.97}, {"GQS": 18.11, "Date": "2010-07-26", "CBM": 3.55}, {"GQS": 18.41, "Date": "2010-07-19", "CBM": 3.5}, {"GQS": 18.13, "Date": "2010-07-12", "CBM": 3.11}, {"GQS": 18.53, "Date": "2010-07-06", "CBM": 3.11}, {"GQS": 19.48, "Date": "2010-06-28", "CBM": 2.98}, {"GQS": 20.2, "Date": "2010-06-21", "CBM": 3.4}, {"GQS": 21.24, "Date": "2010-06-14", "CBM": 3.75}, {"GQS": 21.99, "Date": "2010-06-07", "CBM": 3.71}, {"GQS": 20.96, "Date": "2010-06-01", "CBM": 3.78}, {"GQS": 21.8, "Date": "2010-05-24", "CBM": 4.17}, {"GQS": 22.15, "Date": "2010-05-17", "CBM": 4.36}, {"GQS": 22.96, "Date": "2010-05-10", "CBM": 4.46}, {"GQS": 22.27, "Date": "2010-05-03", "CBM": 4.25}, {"GQS": 24.73, "Date": "2010-04-26", "CBM": 4.39}, {"GQS": 26.06, "Date": "2010-04-19", "CBM": 4.3}, {"GQS": 25, "Date": "2010-04-12", "CBM": 4.42}, {"GQS": 24.85, "Date": "2010-04-05", "CBM": 4.37}, {"GQS": 23.63, "Date": "2010-03-29", "CBM": 4.11}, {"GQS": 23.42, "Date": "2010-03-22", "CBM": 3.88}, {"GQS": 23.22, "Date": "2010-03-15", "CBM": 4.25}, {"GQS": 22.8, "Date": "2010-03-08", "CBM": 4.23}, {"GQS": 22.32, "Date": "2010-03-01", "CBM": 4.24}, {"GQS": 21.5, "Date": "2010-02-22", "CBM": 3.77}, {"GQS": 19.85, "Date": "2010-02-16", "CBM": 4.11}, {"GQS": 19.95, "Date": "2010-02-08", "CBM": 4.31}, {"GQS": 19.88, "Date": "2010-02-01", "CBM": 5.19}, {"GQS": 19.08, "Date": "2010-01-25", "CBM": 5.38}, {"GQS": 18.86, "Date": "2010-01-19", "CBM": 5.74}, {"GQS": 19.56, "Date": "2010-01-11", "CBM": 5.83}, {"GQS": 20.4, "Date": "2010-01-04", "CBM": 5.68}, {"GQS": 20.95, "Date": "2009-12-28", "CBM": 5.58}, {"GQS": 20.71, "Date": "2009-12-21", "CBM": 5.69}, {"GQS": 20.89, "Date": "2009-12-14", "CBM": 5.43}, {"GQS": 21.46, "Date": "2009-12-07", "CBM": 5.35}, {"GQS": 21.77, "Date": "2009-11-30", "CBM": 5.48}, {"GQS": 22.03, "Date": "2009-11-23", "CBM": 5.7}, {"GQS": 21.95, "Date": "2009-11-16", "CBM": 5.86}, {"GQS": 22.42, "Date": "2009-11-09", "CBM": 6.15}, {"GQS": 23.03, "Date": "2009-11-02", "CBM": 6.27}, {"GQS": 21.34, "Date": "2009-10-26", "CBM": 6}, {"GQS": 22.02, "Date": "2009-10-19", "CBM": 6.78}, {"GQS": 22.96, "Date": "2009-10-12", "CBM": 6.95}, {"GQS": 22.24, "Date": "2009-10-05", "CBM": 6.77}, {"GQS": 20.81, "Date": "2009-09-28", "CBM": 6.12}, {"GQS": 21.48, "Date": "2009-09-21", "CBM": 6.15}, {"GQS": 22.02, "Date": "2009-09-14", "CBM": 6.43}, {"GQS": 21.6, "Date": "2009-09-08", "CBM": 6.06}, {"GQS": 21.12, "Date": "2009-08-31", "CBM": 5.72}, {"GQS": 19.93, "Date": "2009-08-24", "CBM": 5.52}, {"GQS": 19.48, "Date": "2009-08-17", "CBM": 5.36}, {"GQS": 18.78, "Date": "2009-08-10", "CBM": 4.66}, {"GQS": 18.58, "Date": "2009-08-03", "CBM": 4.58}, {"GQS": 16.32, "Date": "2009-07-27", "CBM": 4.58}, {"GQS": 15.94, "Date": "2009-07-20", "CBM": 4.46}, {"GQS": 16.17, "Date": "2009-07-13", "CBM": 4.4}, {"GQS": 14.96, "Date": "2009-07-06", "CBM": 4.1}, {"GQS": 15.39, "Date": "2009-06-29", "CBM": 4.05}, {"GQS": 16.06, "Date": "2009-06-22", "CBM": 4.48}, {"GQS": 15.8, "Date": "2009-06-15", "CBM": 4.2}, {"GQS": 16.37, "Date": "2009-06-08", "CBM": 4}, {"GQS": 16.63, "Date": "2009-06-01", "CBM": 4.1}, {"GQS": 17.85, "Date": "2009-05-26", "CBM": 3.6}, {"GQS": 16.39, "Date": "2009-05-18", "CBM": 3.91}, {"GQS": 15.16, "Date": "2009-05-11", "CBM": 3.71}, {"GQS": 16.55, "Date": "2009-05-04", "CBM": 4}, {"GQS": 15.77, "Date": "2009-04-27", "CBM": 2.45}, {"GQS": 15.28, "Date": "2009-04-20", "CBM": 2.58}, {"GQS": 15.12, "Date": "2009-04-13", "CBM": 2.78}, {"GQS": 15.09, "Date": "2009-04-06", "CBM": 2.84}, {"GQS": 15.25, "Date": "2009-03-30", "CBM": 2.3}, {"GQS": 13.06, "Date": "2009-03-23", "CBM": 2.48}, {"GQS": 11.98, "Date": "2009-03-16", "CBM": 2.49}, {"GQS": 11.99, "Date": "2009-03-09", "CBM": 1.75}, {"GQS": 9.85, "Date": "2009-03-02", "CBM": 1.5}, {"GQS": 10.79, "Date": "2009-02-23", "CBM": 2.16}, {"GQS": 11.55, "Date": "2009-02-17", "CBM": 3.3}, {"GQS": 11.62, "Date": "2009-02-09", "CBM": 3.98}, {"GQS": 11.94, "Date": "2009-02-02", "CBM": 4.62}, {"GQS": 11.28, "Date": "2009-01-26", "CBM": 3.27}, {"GQS": 12, "Date": "2009-01-20", "CBM": 3.5}, {"GQS": 12.14, "Date": "2009-01-12", "CBM": 4.3}, {"GQS": 12.99, "Date": "2009-01-05", "CBM": 4.45}, {"GQS": 14.07, "Date": "2008-12-29", "CBM": 4.35}, {"GQS": 12.97, "Date": "2008-12-22", "CBM": 4.52}, {"GQS": 13.57, "Date": "2008-12-15", "CBM": 4.63}, {"GQS": 13.19, "Date": "2008-12-08", "CBM": 3.86}, {"GQS": 14.01, "Date": "2008-12-01", "CBM": 3.69}, {"GQS": 13.02, "Date": "2008-11-24", "CBM": 3.48}, {"GQS": 12.1, "Date": "2008-11-17", "CBM": 2.5}, {"GQS": 11.55, "Date": "2008-11-10", "CBM": 2.94}, {"GQS": 12.82, "Date": "2008-11-03", "CBM": 3.88}, {"GQS": 12.94, "Date": "2008-10-27", "CBM": 4.5}, {"GQS": 11.21, "Date": "2008-10-20", "CBM": 4.59}, {"GQS": 13.42, "Date": "2008-10-13", "CBM": 4.98}, {"GQS": 13.82, "Date": "2008-10-06", "CBM": 4.36}, {"GQS": 16.83, "Date": "2008-09-29", "CBM": 4.59}, {"GQS": 18.37, "Date": "2008-09-22", "CBM": 6.38}, {"GQS": 19.08, "Date": "2008-09-15", "CBM": 6.6}, {"GQS": 19.37, "Date": "2008-09-08", "CBM": 6.48}, {"GQS": 19.19, "Date": "2008-09-02", "CBM": 6.24}, {"GQS": 19.45, "Date": "2008-08-25", "CBM": 6.51}, {"GQS": 19.88, "Date": "2008-08-18", "CBM": 6.73}, {"GQS": 19.4, "Date": "2008-08-11", "CBM": 6.74}, {"GQS": 18.09, "Date": "2008-08-04", "CBM": 6.6}, {"GQS": 16.34, "Date": "2008-07-28", "CBM": 7.69}, {"GQS": 16.29, "Date": "2008-07-21", "CBM": 7.89}, {"GQS": 16.6, "Date": "2008-07-14", "CBM": 6.83}, {"GQS": 15.25, "Date": "2008-07-07", "CBM": 6.03}, {"GQS": 16.45, "Date": "2008-06-30", "CBM": 5.45}, {"GQS": 16.74, "Date": "2008-06-23", "CBM": 5.98}, {"GQS": 17.45, "Date": "2008-06-16", "CBM": 6.48}, {"GQS": 18, "Date": "2008-06-09", "CBM": 6.32}, {"GQS": 17.17, "Date": "2008-06-02", "CBM": 6.35}, {"GQS": 18.25, "Date": "2008-05-27", "CBM": 6.15}, {"GQS": 17.94, "Date": "2008-05-19", "CBM": 5.59}, {"GQS": 18.43, "Date": "2008-05-12", "CBM": 5.99}, {"GQS": 17.94, "Date": "2008-05-05", "CBM": 5.51}, {"GQS": 18.68, "Date": "2008-04-28", "CBM": 5.96}, {"GQS": 19.34, "Date": "2008-04-21", "CBM": 5.97}, {"GQS": 19, "Date": "2008-04-14", "CBM": 5.95}, {"GQS": 17.95, "Date": "2008-04-07", "CBM": 6.2}, {"GQS": 19.05, "Date": "2008-03-31", "CBM": 7.09}, {"GQS": 19.52, "Date": "2008-03-24", "CBM": 6.94}, {"GQS": 21.37, "Date": "2008-03-17", "CBM": 8.01}, {"GQS": 19.81, "Date": "2008-03-10", "CBM": 7.83}, {"GQS": 19.58, "Date": "2008-03-03", "CBM": 7.94}, {"GQS": 20.17, "Date": "2008-02-25", "CBM": 8.73}, {"GQS": 19.71, "Date": "2008-02-19", "CBM": 9.48}, {"GQS": 19.7, "Date": "2008-02-11", "CBM": 9.84}, {"GQS": 19.78, "Date": "2008-02-04", "CBM": 10.46}, {"GQS": 19.34, "Date": "2008-01-28", "CBM": 9.73}, {"GQS": 17.8, "Date": "2008-01-22", "CBM": 9.32}, {"GQS": 17.23, "Date": "2008-01-14", "CBM": 9.76}, {"GQS": 17.2, "Date": "2008-01-07", "CBM": 8.57}, {"GQS": 19.66, "Date": "2007-12-31", "CBM": 7.8}, {"GQS": 21.36, "Date": "2007-12-24", "CBM": 8.36}, {"GQS": 21.76, "Date": "2007-12-17", "CBM": 9.03}, {"GQS": 21.18, "Date": "2007-12-10", "CBM": 8.5}, {"GQS": 21.57, "Date": "2007-12-03", "CBM": 8.24}, {"GQS": 20.4, "Date": "2007-11-26", "CBM": 7.74}, {"GQS": 18.89, "Date": "2007-11-19", "CBM": 7.71}, {"GQS": 20.09, "Date": "2007-11-12", "CBM": 7.97}, {"GQS": 19.38, "Date": "2007-11-05", "CBM": 9.17}, {"GQS": 18.21, "Date": "2007-10-29", "CBM": 10.52}, {"GQS": 18.61, "Date": "2007-10-22", "CBM": 11.37}, {"GQS": 17.75, "Date": "2007-10-15", "CBM": 10.67}, {"GQS": 19.01, "Date": "2007-10-08", "CBM": 11.45}, {"GQS": 18.91, "Date": "2007-10-01", "CBM": 10.88}, {"GQS": 18.44, "Date": "2007-09-24", "CBM": 10.89}, {"GQS": 18.55, "Date": "2007-09-17", "CBM": 12.06}, {"GQS": 18, "Date": "2007-09-10", "CBM": 11.33}, {"GQS": 17.94, "Date": "2007-09-04", "CBM": 11.42}, {"GQS": 18.76, "Date": "2007-08-27", "CBM": 12.47}, {"GQS": 18.51, "Date": "2007-08-20", "CBM": 12.83}, {"GQS": 17.27, "Date": "2007-08-13", "CBM": 13.38}, {"GQS": 16.75, "Date": "2007-08-06", "CBM": 11.81}, {"GQS": 16.44, "Date": "2007-07-30", "CBM": 12.96}, {"GQS": 17.79, "Date": "2007-07-23", "CBM": 13.3}, {"GQS": 18.63, "Date": "2007-07-16", "CBM": 13.69}, {"GQS": 18.56, "Date": "2007-07-09", "CBM": 14.35}, {"GQS": 19.22, "Date": "2007-07-02", "CBM": 13.58}, {"GQS": 19.1, "Date": "2007-06-25", "CBM": 13.27}, {"GQS": 19.34, "Date": "2007-06-18", "CBM": 13.45}, {"GQS": 18.97, "Date": "2007-06-11", "CBM": 13.4}, {"GQS": 18.47, "Date": "2007-06-04", "CBM": 12.69}, {"GQS": 18.51, "Date": "2007-05-29", "CBM": 12.53}, {"GQS": 18.18, "Date": "2007-05-21", "CBM": 12.53}, {"GQS": 18.44, "Date": "2007-05-14", "CBM": 12.53}, {"GQS": 18.32, "Date": "2007-05-07", "CBM": 12.13}, {"GQS": 18.5, "Date": "2007-04-30", "CBM": 11.67}, {"GQS": 18.31, "Date": "2007-04-23", "CBM": 24.56}, {"GQS": 18.96, "Date": "2007-04-16", "CBM": 25.04}, {"GQS": 18.47, "Date": "2007-04-09", "CBM": 25.45}, {"GQS": 17.64, "Date": "2007-04-02", "CBM": 24.97}, {"GQS": 17.21, "Date": "2007-03-26", "CBM": 24.6}, {"GQS": 17.85, "Date": "2007-03-19", "CBM": 24.84}, {"GQS": 17.5, "Date": "2007-03-12", "CBM": 24.5}, {"GQS": 17.84, "Date": "2007-03-05", "CBM": 23.13}, {"GQS": 18.4, "Date": "2007-02-26", "CBM": 22.67}, {"GQS": 19.81, "Date": "2007-02-20", "CBM": 23.49}, {"GQS": 20.02, "Date": "2007-02-12", "CBM": 23.5}, {"GQS": 19.55, "Date": "2007-02-05", "CBM": 23.38}, {"GQS": 19.47, "Date": "2007-01-29", "CBM": 21.92}, {"GQS": 19.04, "Date": "2007-01-22", "CBM": 21.46}, {"GQS": 20, "Date": "2007-01-16", "CBM": 22.05}, {"GQS": 20.3, "Date": "2007-01-08", "CBM": 22.33}, {"GQS": 18.89, "Date": "2007-01-03", "CBM": 22.37}, {"GQS": 19.5, "Date": "2006-12-26", "CBM": 22.72}, {"GQS": 19.95, "Date": "2006-12-18", "CBM": 22.88}, {"GQS": 20.39, "Date": "2006-12-11", "CBM": 22.39}, {"GQS": 19.66, "Date": "2006-12-04", "CBM": 22.6}, {"GQS": 18.68, "Date": "2006-11-27", "CBM": 22.12}, {"GQS": 19.3, "Date": "2006-11-20", "CBM": 22.31}, {"GQS": 19.81, "Date": "2006-11-13", "CBM": 22.39}, {"GQS": 20.19, "Date": "2006-11-06", "CBM": 22.66}, {"GQS": 19.57, "Date": "2006-10-30", "CBM": 22.67}, {"GQS": 20.72, "Date": "2006-10-23", "CBM": 23.88}, {"GQS": 19.3, "Date": "2006-10-16", "CBM": 21.53}, {"GQS": 19.85, "Date": "2006-10-09", "CBM": 21.59}, {"GQS": 19.07, "Date": "2006-10-02", "CBM": 21.37}, {"GQS": 18.95, "Date": "2006-09-25", "CBM": 20.71}, {"GQS": 18.39, "Date": "2006-09-18", "CBM": 21.05}, {"GQS": 17.92, "Date": "2006-09-11", "CBM": 21.7}, {"GQS": 16.9, "Date": "2006-09-05", "CBM": 21.18}, {"GQS": 16.9, "Date": "2006-08-28", "CBM": 22.76}, {"GQS": 16.61, "Date": "2006-08-21", "CBM": 21.52}, {"GQS": 16.65, "Date": "2006-08-14", "CBM": 21.13}, {"GQS": 16.9, "Date": "2006-08-07", "CBM": 19.78}, {"GQS": 16.75, "Date": "2006-07-31", "CBM": 20.94}, {"GQS": 17.12, "Date": "2006-07-24", "CBM": 21.59}]}, "created": "2017-05-24T03:21:07.631Z", "updated": "2017-05-24T03:21:20.890Z", "author": null, "creator": null, "icon": "", "description": null}}, {"model": "chartwerk.template", "pk": 6, "fields": {"slug": "us-choropleth-map", "title": "US choropleth map", "data": {"text": {"chatter": "States that are either open or closed.", "annotations": [], "source": "SOURCE: New York Stock Exchange", "legend": {"single": {"inside": false, "position": {"x": 10, "y": 10}, "align": "l", "background": true, "width": 250}, "double": {"inside": false, "position": {"x": 10, "y": 10}, "align": "l", "background": true, "width": 500}, "title": "", "active": false, "keys": [{"text": "", "color": "#329CEB"}, {"text": "", "color": "#52B033"}]}, "author": "John Doe / DMN", "headline": "State-craft", "title": "", "footnote": ""}, "template": {"icon": null, "tags": ["map"], "description": "Use this map if you want to compare states.\n\nYour data must include a column of state names, either as full text, like \"Texas,\" or as postal abbreviations, like \"TX.\" This column should be classified as a \"Base axis.\"\n\nYou should classify your value column as a \"Scale column\" on the data tab.", "title": "US state choropleth map"}, "embed": {"dimensions": {}}, "scripts": {"helper": "var werkHelper = {\n    prototype: function() {\n        d3.selection.prototype.moveToFront = function() {\n          return this.each(function(){\n            this.parentNode.appendChild(this);\n          });\n        };\n    },\n    \n    parse: function(werk){\n        werk.data = chartwerk.data.map(function(d){\n            return {\n                state: d[chartwerk.datamap.base],\n                value: chartwerk.axes.color.quantize ? \n                    +d[chartwerk.datamap.scale] : d[chartwerk.datamap.scale],\n                tooltip: chartwerk.datamap.custom.tooltip !== '' ?\n                    d[chartwerk.datamap.custom.tooltip] : null,\n            };\n        });\n    },\n    \n    dims: function(werk){\n        var s = chartwerk.ui.size;\n            w = werk.dims[s].width,\n            h = werk.dims[s].height,\n            margins = {\n                right: chartwerk.margins[s].right * w,\n                left: chartwerk.margins[s].left * w,\n                top: chartwerk.margins[s].top * h,\n                bottom: chartwerk.margins[s].bottom * h\n            },\n            svg = {\n                width: w - margins.left - margins.right,\n                height: h - margins.top - margins.bottom\n            };\n        \n        werk.dims.margins = margins;\n        werk.dims.svg = svg;\n    },\n\n    scales: function(werk){\n        var svg = werk.dims.svg;\n        werk.scales = {\n            color: chartwerk.axes.color.quantize ? \n                d3.scaleThreshold() : d3.scaleOrdinal(),\n        };\n        \n        werk.scales.color\n            .domain(chartwerk.axes.color.domain)\n            .range(chartwerk.axes.color.range);\n    },\n\n    // Build dims, scales and axes.\n    build: function(werk){\n        this.prototype();\n        this.parse(werk);\n        this.dims(werk);\n        this.scales(werk);\n        return werk;\n    },\n};\n\n", "draw": "function draw(){\n    var initialProps = {\n        dims: {\n          single: { width: 270, height: 205 },\n          double: { width: 580, height: 370}\n        },\n    };\n    \n    var werk = werkHelper.build(initialProps);\n\t\n\tvar comma = d3.format(\",\");\n\n    var map = d3.map(werk.data, function(d){ return d.state; }),\n        path = d3.geoPath(),\n        postal = werk.data[0].state.length === 2; // If state label is a postal code\n\t\n\tvar svg = d3.select(\"#chart\").append(\"svg\")\n      .style(\"background-color\",\"transparent\")\n        .attr(\"width\", werk.dims.svg.width + werk.dims.margins.left + werk.dims.margins.right)\n        .attr(\"height\", werk.dims.svg.height + werk.dims.margins.top + werk.dims.margins.bottom)\n      .append(\"g\")\n        .attr(\"transform\", \"translate(\" + werk.dims.margins.left + \",\" + werk.dims.margins.top + \")\");\n    \n    var projection = d3.geoAlbersUsa()\n        // Scale for different sizes\n        .scale(chartwerk.ui.size === 'double' ? 720 : 350);\n\n    function getState(d){\n        return postal ? map.get(d.properties.ABBREVIATION) : map.get(d.properties.NAME);\n    }\n    \n    d3.json(\"//interactives.dallasnews.com/common/data/geo/us-states.json\", function(error, us_states){\n\n        var states = svg.append(\"g\")\n            .attr(\"id\", \"states\")\n            // Have to recenter, probably because this map originally had Puerto Rico in it...\n            .attr(\"transform\", chartwerk.ui.size === 'double' ? \"translate(-220, -90)\" : \"translate(-360, -160)\")\n            .selectAll(\"path\")\n            .data(topojson.feature(us_states, us_states.objects.us_states).features)\n            .enter().append(\"path\")\n            .attr('d', d3.geoPath().projection(projection))\n            .attr(\"class\", \"state\")\n            .style('fill', function(d){ \n                return werk.scales.color(getState(d).value);\n            })\n            .style(\"stroke\", \"#fff\")\n            .on(\"mouseover\",function(d){\n                d3.select(this)\n                  .style(\"stroke\", \"black\")\n                  .moveToFront();\n                d3.select(\".tooltip .title\")\n                  .text(d.properties.NAME);\n                d3.select(\".tooltip .value\")\n                  .text(function(){\n                      var s = chartwerk.axes.scale;\n                      var data = getState(d);\n                      if (data.tooltip){\n                          return data.tooltip;\n                      } else {\n                          return chartwerk.axes.color.quantize ? \n                            s.prefix + comma(data.value) + s.suffix : data.value;\n                      }\n                  });\n                var p = d3.mouse(this.parentElement.parentElement);\n                d3.select(\".tooltip\")\n                    .style(\"opacity\", 1)\n                    .style(\"top\",function(){\n                        return p[1].toString() + \"px\";\n                    })\n                    .style(\"left\", function(){\n                        // We position either left or right of the mouse point based\n                        // on whether we're past the midpoint of the chart. This protects\n                        // against tooltips overflowing embedded iframes.\n                        var s = chartwerk.ui.size,\n                            w = werk.dims[s].width,\n                            tipW = parseInt(d3.select(\".tooltip\").style(\"width\"), 10),\n                            pos = p[0] > (w / 2) ?\n                                p[0] - (tipW - 10) : p[0] + 40;\n                        return pos.toString() + \"px\";\n                    });\n            })\n            .on(\"mouseout\",function(){\n                d3.select(this)\n                  .style(\"stroke\",\"#fff\")\n                  .style('fill', function(d){ \n                      return werk.scales.color(getState(d).value);\n                });\n                d3.select(\".tooltip\")\n                    .style(\"opacity\", 0);\n            });\n    });\n    \n    var tooltip = d3.select(\"#chart\")\n      .append(\"div\")\n        .attr(\"class\",\"tooltip\")\n        .style(\"position\",\"absolute\");\n    tooltip\n      .append(\"div\")\n      .attr(\"class\",\"title\")\n      .text(chartwerk.datamap.scale);\n    tooltip\n      .append(\"div\")\n      .attr(\"class\",\"value\");\n}", "styles": "#chartwerk {\n    font-family:'Gotham A', 'Gotham B', arial, sans-serif; \n    width:600px;\n}\n#chartwerk #chart {\n    background: white;\n}\n#chartwerk.single{\n    width:290px;\n    float:left;\n    overflow:hidden;\n    margin:10px 30px 10px 0;\n}\n#chartwerk #headline { \n    font-weight:bold;\n    font-size:24px;\n}\n#chartwerk #chatter {\n    margin-top:5px;\n}\n#chartwerk #footnote,\n#chartwerk #source,\n#chartwerk #author {\n    font-size:11px;\n    color:grey;\n\n}\n#chartwerk #author {\n    text-align:right;\n}\n\n#chartwerk #chart-legend \n.chart-legend-container .key-label{\n    font:11px 'Gotham A', 'Gotham B', arial, sans-serif;\n}\n#chartwerk #chart path.line{\n    fill: none;\n    stroke-width: 2px;\n}\n#chartwerk #chart-legend{\n    margin-top:10px;\n}\n\n#chartwerk #chart path.state{\n    stroke-width:1px;\n    cursor:crosshair;\n}\n#chartwerk #chart{\n    position:relative;\n}\n#chartwerk #chart .tooltip{\n    font: 13px 'Gotham A', 'Gotham B', arial, sans-serif;\n    opacity:0;\n    pointer-events:none;\n    background:rgba(255,255,255,.75);\n    padding:5px;\n    width:auto;\n}\n#chartwerk #chart .tooltip .title{\n    font-weight: bold;\n    fill:grey;\n}", "dependencies": {"styles": ["https://cloud.typography.com/6922714/7642152/css/fonts.css", "https://interactives.dallasnews.com/common/fonts/gotham.css"], "scripts": ["https://cdnjs.cloudflare.com/ajax/libs/d3/4.2.3/d3.min.js", "https://cdnjs.cloudflare.com/ajax/libs/topojson/1.6.20/topojson.min.js"]}, "html": "<div id='chart-header'>\n\t<h2 id='headline'></h2>\n\t<div id='chatter'></div> \n</div> \n<div id='chart-ui'>\n\t<!--You can put any necessary buttons, etc., here.-->\n</div>\n<div id='chart-legend'></div>\n<div id='chart'></div> \n<div id='chart-footer'> \n\t<div id='footnote'></div> \n\t<div id='source'></div> \n\t<div id='author'></div> \n</div>"}, "datamap": {"value": null, "custom": {"tooltip": "Tooltip"}, "ignore": [], "scale": "Status", "series": [], "sort": ["State", "Status", "Tooltip"], "facet": null, "base": "State"}, "axes": {"color": {"ignoreScale": false, "domain": ["closed", "open"], "byFacet": false, "quantizeProps": {"reverseColors": false, "groups": 0, "column": null}, "scheme": "categorical.default", "quantize": false, "range": ["#329CEB", "#52B033"]}, "value": {"prefix": "$", "suffix": "", "min": null, "shadedRegions": [], "label": "", "max": null, "format": {"single": {"customTicks": [], "ticks": 7}, "double": {"customTicks": [], "ticks": 7}}}, "scale": {"prefix": "", "suffix": ""}, "base": {"prefix": "", "type": "categorical", "suffix": "", "min": null, "shadedRegions": [], "label": "", "max": null, "dateFormat": null, "format": {"single": {"customTicks": [], "dateString": "Y", "ticks": 7, "frequency": 2}, "double": {"customTicks": [], "dateString": "Y", "ticks": 7, "frequency": 1}}}}, "ui": {"size": "double", "rawData": "State\tStatus\tTooltip\nAL\tclosed\tThis state is closed\nAK\tclosed\tThis state is closed\nAZ\topen\tThis state is open\nAR\tclosed\tThis state is closed\nCA\tclosed\tThis state is closed\nCO\tclosed\tThis state is closed\nCT\tclosed\tThis state is closed\nDE\tclosed\tThis state is closed\nFL\tclosed\tThis state is closed\nGA\topen\tThis state is open\nHI\tclosed\tThis state is closed\nID\tclosed\tThis state is closed\nIL\tclosed\tThis state is closed\nIN\tclosed\tThis state is closed\nIA\tclosed\tThis state is closed\nKS\topen\tThis state is open\nKY\tclosed\tThis state is closed\nLA\tclosed\tThis state is closed\nME\tclosed\tThis state is closed\nMD\topen\tThis state is open\nMA\tclosed\tThis state is closed\nMI\tclosed\tThis state is closed\nMN\topen\tThis state is open\nMS\tclosed\tThis state is closed\nMO\tclosed\tThis state is closed\nMT\tclosed\tThis state is closed\nNE\topen\tThis state is open\nNV\tclosed\tThis state is closed\nNH\tclosed\tThis state is closed\nNJ\topen\tThis state is open\nNM\tclosed\tThis state is closed\nNY\tclosed\tThis state is closed\nNC\tclosed\tThis state is closed\nND\topen\tThis state is open\nOH\topen\tThis state is open\nOK\tclosed\tThis state is closed\nOR\topen\tThis state is open\nPA\topen\tThis state is open\nRI\tclosed\tThis state is closed\nSC\tclosed\tThis state is closed\nSD\tclosed\tThis state is closed\nTN\topen\tThis state is open\nTX\tclosed\tThis state is closed\nUT\tclosed\tThis state is closed\nVT\tclosed\tThis state is closed\nVA\tclosed\tThis state is closed\nWA\tclosed\tThis state is closed\nWV\tclosed\tThis state is closed\nWI\tclosed\tThis state is closed\nWY\tclosed\tThis state is closed\n", "datamap": [{"available": true, "class": "base", "alias": "State"}, {"available": false, "class": "value", "alias": "value axis"}, {"available": true, "class": "scale", "alias": "Color value"}, {"available": false, "class": "series", "alias": "data series"}, {"available": false, "class": "facet", "alias": "faceting column"}, {"available": false, "class": "ignore", "alias": "ignored column"}, {"available": true, "class": "tooltip", "alias": "Tooltip"}]}, "margins": {"single": {"left": 0.05, "top": 0.05, "right": 0.050000000000000044, "bottom": 0.050000000000000044}, "double": {"left": 0.05, "top": 0.05, "right": 0.050000000000000044, "bottom": 0.050000000000000044}}, "data": [{"Tooltip": "This state is closed", "State": "AL", "Status": "closed"}, {"Tooltip": "This state is closed", "State": "AK", "Status": "closed"}, {"Tooltip": "This state is open", "State": "AZ", "Status": "open"}, {"Tooltip": "This state is closed", "State": "AR", "Status": "closed"}, {"Tooltip": "This state is closed", "State": "CA", "Status": "closed"}, {"Tooltip": "This state is closed", "State": "CO", "Status": "closed"}, {"Tooltip": "This state is closed", "State": "CT", "Status": "closed"}, {"Tooltip": "This state is closed", "State": "DE", "Status": "closed"}, {"Tooltip": "This state is closed", "State": "FL", "Status": "closed"}, {"Tooltip": "This state is open", "State": "GA", "Status": "open"}, {"Tooltip": "This state is closed", "State": "HI", "Status": "closed"}, {"Tooltip": "This state is closed", "State": "ID", "Status": "closed"}, {"Tooltip": "This state is closed", "State": "IL", "Status": "closed"}, {"Tooltip": "This state is closed", "State": "IN", "Status": "closed"}, {"Tooltip": "This state is closed", "State": "IA", "Status": "closed"}, {"Tooltip": "This state is open", "State": "KS", "Status": "open"}, {"Tooltip": "This state is closed", "State": "KY", "Status": "closed"}, {"Tooltip": "This state is closed", "State": "LA", "Status": "closed"}, {"Tooltip": "This state is closed", "State": "ME", "Status": "closed"}, {"Tooltip": "This state is open", "State": "MD", "Status": "open"}, {"Tooltip": "This state is closed", "State": "MA", "Status": "closed"}, {"Tooltip": "This state is closed", "State": "MI", "Status": "closed"}, {"Tooltip": "This state is open", "State": "MN", "Status": "open"}, {"Tooltip": "This state is closed", "State": "MS", "Status": "closed"}, {"Tooltip": "This state is closed", "State": "MO", "Status": "closed"}, {"Tooltip": "This state is closed", "State": "MT", "Status": "closed"}, {"Tooltip": "This state is open", "State": "NE", "Status": "open"}, {"Tooltip": "This state is closed", "State": "NV", "Status": "closed"}, {"Tooltip": "This state is closed", "State": "NH", "Status": "closed"}, {"Tooltip": "This state is open", "State": "NJ", "Status": "open"}, {"Tooltip": "This state is closed", "State": "NM", "Status": "closed"}, {"Tooltip": "This state is closed", "State": "NY", "Status": "closed"}, {"Tooltip": "This state is closed", "State": "NC", "Status": "closed"}, {"Tooltip": "This state is open", "State": "ND", "Status": "open"}, {"Tooltip": "This state is open", "State": "OH", "Status": "open"}, {"Tooltip": "This state is closed", "State": "OK", "Status": "closed"}, {"Tooltip": "This state is open", "State": "OR", "Status": "open"}, {"Tooltip": "This state is open", "State": "PA", "Status": "open"}, {"Tooltip": "This state is closed", "State": "RI", "Status": "closed"}, {"Tooltip": "This state is closed", "State": "SC", "Status": "closed"}, {"Tooltip": "This state is closed", "State": "SD", "Status": "closed"}, {"Tooltip": "This state is open", "State": "TN", "Status": "open"}, {"Tooltip": "This state is closed", "State": "TX", "Status": "closed"}, {"Tooltip": "This state is closed", "State": "UT", "Status": "closed"}, {"Tooltip": "This state is closed", "State": "VT", "Status": "closed"}, {"Tooltip": "This state is closed", "State": "VA", "Status": "closed"}, {"Tooltip": "This state is closed", "State": "WA", "Status": "closed"}, {"Tooltip": "This state is closed", "State": "WV", "Status": "closed"}, {"Tooltip": "This state is closed", "State": "WI", "Status": "closed"}, {"Tooltip": "This state is closed", "State": "WY", "Status": "closed"}]}, "created": "2017-05-24T03:22:42.346Z", "updated": "2017-05-24T03:22:59.623Z", "author": null, "creator": null, "icon": "", "description": null}}, {"model": "chartwerk.template", "pk": 7, "fields": {"slug": "horizontal-bar-chart-paragraph-text", "title": "horizontal-bar-chart-paragraph-text", "data": {"text": {"chatter": "Twenty-three and one quarter people were asked, \"How was your day?\"", "annotations": [], "source": "SOURCE: Pew Research", "legend": {"single": {"inside": false, "position": {"x": 10, "y": 10}, "align": "l", "background": true, "width": 250}, "double": {"inside": false, "position": {"x": 10, "y": 10}, "align": "l", "background": true, "width": 500}, "title": "", "active": false, "keys": []}, "author": "Jane Doe / DMN", "headline": "Carpe Diem", "title": "", "footnote": ""}, "template": {"icon": null, "tags": [], "description": "This horizontal bar chart accomodates particularly long text labels. It's great for displaying survey data in which responses can be as long as whole sentences.", "title": "Horizontal bar chart (paragraph text)"}, "embed": {"dimensions": {}}, "scripts": {"helper": "var werkHelper = {\n    parse: function(werk){\n        \n        werk.data = chartwerk.data.map(function(d){\n            return {\n                name: d[chartwerk.datamap.base],\n                value: d[chartwerk.datamap.value]\n            };\n        })\n        .sort(function(a, b){ return d3.descending(a.value, b.value); });\n    },\n    \n    dims: function(werk){\n        var s = chartwerk.ui.size;\n            w = werk.dims[s].width,\n            h = werk.dims[s].height,\n            margins = {\n                right: chartwerk.margins[s].right * w,\n                left: chartwerk.margins[s].left * w,\n                top: chartwerk.margins[s].top * h,\n                bottom: chartwerk.margins[s].bottom * h\n            },\n            div = {\n                width: w - margins.left - margins.right,\n                height: h - margins.top - margins.bottom\n            };\n        \n        werk.dims.margins = margins;\n        werk.dims.div = div;\n    },\n\n    scales: function(werk){\n        var div = werk.dims.div;\n        werk.scales = {\n            x: d3.scaleLinear()\n                .range([0, div.width]),\n        };\n    },\n    \n\n    valueDomain: function(werk){\n        var max = d3.max(werk.data, function(d) { \n                return d.value; \n            });\n        \n        if (chartwerk.axes.value.min && chartwerk.axes.value.max) {\n            werk.scales.x.domain(\n                [chartwerk.axes.value.min, chartwerk.axes.value.max]\n            );\n        } else if (chartwerk.axes.value.min) {\n            werk.scales.x.domain(\n                [chartwerk.axes.value.min, max ]\n            );\n        } else if (chartwerk.axes.value.max) {\n            werk.scales.x.domain(\n                [0, chartwerk.axes.value.max]\n            );\n        } else {\n            werk.scales.x.domain([0, max]);\n        }\n        \n        werk.scales.x.nice();\n    },\n\n\n    // Build dims, scales and axes.\n    build: function(werk){\n        this.parse(werk);\n        this.dims(werk);\n        this.scales(werk);\n        this.valueDomain(werk);\n        return werk;\n    },\n};", "draw": "function draw(){\n\n    var initialProps = {\n        dims: {\n          single: { width: 260, height: 225 },\n          double: { width: 540, height: 250}\n        },\n    };\n    \n    // Returns object with properties and methods representing\n    // dimensions, scales, axes, etc.\n    var werk = werkHelper.build(initialProps);\n    \n    var comma = d3.format(\",\");\n    \n    var div = d3.select(\"#chart\")\n        .append(\"div\")\n        .style(\"margin\", \n            werk.dims.margins.top + \"px \" +\n            werk.dims.margins.right + \"px \" +\n            werk.dims.margins.bottom + \"px \" +\n            werk.dims.margins.left + \"px \"\n        );\n    \n    \n    var response = div.selectAll(\".response\")\n        .data(werk.data)\n      .enter().append(\"div\")\n        .attr(\"class\",\"response\");\n    \n    response.append(\"p\")\n    \t\t.text(function(d){ return d.name; });\n    \n    response.append(\"div\")\n        .attr(\"class\", \"bar\")\n        .style(\"background-color\", chartwerk.axes.color.range[0])\n        .style(\"width\", function(d){ return werk.scales.x(d.value) + 'px'; })\n      .append(\"div\")\n        .attr(\"class\",\"label\")\n      .append(\"p\")\n        .attr(\"class\", function(d){\n            return werk.scales.x(d.value) < 75 ?\n                'offset' : '';\n        })\n        .style(\"width\", function(d){\n            return werk.scales.x(d.value) < 75 ?\n                werk.dims.div.width - this.parentElement.parentElement.clientWidth + 'px' : '';\n        })\n        .style(\"margin-left\", function(d){\n            return werk.scales.x(d.value) < 75 ?\n                this.parentElement.parentElement.clientWidth + 'px' : '';\n        })\n        .text(function(d){\n            return chartwerk.axes.value.prefix + comma(String(d.value)) + chartwerk.axes.value.suffix;\n        });\n    \n\n}", "styles": "#chartwerk {\n    width:560px;\n}\n#chartwerk div{\n    font-family:'Gotham A', 'Gotham B', arial, sans-serif; \n}\n#chartwerk.single{\n    width:270px;\n    float:left;\n    overflow:hidden;\n    margin:10px 30px 10px 0;\n}\n#chartwerk #headline { \n    font-weight:bold;\n    font-size:24px;\n}\n#chartwerk #chatter {\n    margin-top:5px;\n    font-size:14px;\n    line-height:19px;\n}\n#chartwerk #footnote,\n#chartwerk #source,\n#chartwerk #author {\n    font-size:11px;\n    color:grey;\n\n}\n#chartwerk #author {\n    text-align:right;\n}\n#chartwerk #chart{\n    background-color:white;\n}\n#chartwerk .response{\n    margin-top:10px;\n}\n#chartwerk .response p{\n    font: 13px/16px 'Gotham A', 'Gotham B', arial, sans-serif;\n}\n#chartwerk #chart .bar{\n    height:24px;\n    display:inline-block;\n    margin-top:2px;\n}\n#chartwerk #chart .bar .label{\n    width:100%;\n    text-align:right;\n}\n#chartwerk #chart .bar .label p{\n    padding-right:5px;\n    padding-top:4px;\n    font-weight:bold;\n    font-size:14px;\n    line-height:18px;\n    color:#fff;\n}\n#chartwerk #chart .bar .label p.offset{\n    text-align:left;\n    padding-left:3px;\n    color:#666;\n}", "dependencies": {"styles": ["https://cloud.typography.com/6922714/7642152/css/fonts.css", "https://interactives.dallasnews.com/common/fonts/gotham.css"], "scripts": ["https://cdnjs.cloudflare.com/ajax/libs/d3/4.2.3/d3.min.js"]}, "html": "<div id='chart-header'>\n\t<h2 id='headline'></h2>\n\t<div id='chatter'></div> \n</div> \n<div id='chart-ui'>\n\t<!--You can put any necessary buttons, etc., here.-->\n</div>\n<div id='chart-legend'></div>\n<div id='chart'></div> \n<div id='chart-footer'> \n\t<div id='footnote'></div> \n\t<div id='source'></div> \n\t<div id='author'></div> \n</div>"}, "datamap": {"value": "Percent", "custom": {}, "ignore": [], "scale": null, "series": [], "sort": ["Response", "Percent"], "facet": null, "annotations": [], "base": "Response"}, "axes": {"color": {"ignoreScale": false, "domain": ["Percent"], "byFacet": false, "quantizeProps": {"reverseColors": false, "groups": 0, "column": null}, "scheme": "categorical.default", "quantize": false, "range": ["#329CEB"]}, "value": {"prefix": "", "suffix": "%", "min": null, "shadedRegions": [], "label": "", "max": null, "format": {"single": {"customTicks": [], "ticks": 7}, "double": {"customTicks": [], "ticks": 7}}}, "scale": {"prefix": "", "suffix": ""}, "base": {"prefix": "", "type": "categorical", "suffix": "", "min": null, "shadedRegions": [], "label": "", "max": null, "dateFormat": null, "format": {"single": {"customTicks": [], "dateString": "Y", "ticks": 7, "frequency": 2}, "double": {"customTicks": [], "dateString": "Y", "ticks": 7, "frequency": 1}}}}, "ui": {"size": "single", "rawData": "Response\tPercent\nIt was great!\t40\nI was bitten by a feral cat.\t25\nMy mother bought me ice cream, but it melted too quickly.\t15\nI wish I were taller.\t6\n", "datamap": [{"available": true, "class": "base", "alias": "Category"}, {"available": true, "class": "value", "alias": "Value"}, {"available": false, "class": "scale", "alias": "scale axis"}, {"available": false, "class": "series", "alias": "data series"}, {"available": false, "class": "facet", "alias": "faceting column"}, {"available": false, "class": "ignore", "alias": "ignored column"}]}, "margins": {"single": {"left": 0, "top": 0.03, "right": 0, "bottom": 0.040000000000000036}, "double": {"left": 0, "top": 0.03, "right": 0, "bottom": 0.040000000000000036}}, "data": [{"Response": "It was great!", "Percent": 40}, {"Response": "I was bitten by a feral cat.", "Percent": 25}, {"Response": "My mother bought me ice cream, but it melted too quickly.", "Percent": 15}, {"Response": "I wish I were taller.", "Percent": 6}]}, "created": "2017-05-25T01:25:10.857Z", "updated": "2017-05-25T01:25:10.861Z", "author": null, "creator": null, "icon": "", "description": null}}, {"model": "chartwerk.template", "pk": 8, "fields": {"slug": "vertical-bar-chart", "title": "vertical-bar-chart", "data": {"text": {"chatter": "Some states even have more letters in their names and abbreviations than others do.", "annotations": [], "source": "SOURCE: Pew Research", "legend": {"single": {"inside": false, "position": {"x": 10, "y": 10}, "align": "l", "background": true, "width": 250}, "double": {"inside": false, "position": {"x": 10, "y": 10}, "align": "l", "background": true, "width": 500}, "title": "", "active": true, "keys": [{"text": "Abbreviation", "color": "#E34E36"}, {"text": "Full name", "color": "#329CEB"}]}, "author": "Jane Doe / DMN", "headline": "States have names", "title": "", "footnote": ""}, "template": {"icon": null, "tags": [], "description": "Use vertical bar charts when you want to show comparisons of quantity. Examples include population by city, touchdowns by player or sales by vehicle model.\n\nAs a general rule, vertical bar charts should not be used to show trends over time, for example, how many homes are purchased each year. Use a line chart instead.\n\nYour data should contain:\n    * A column with categorical labels (like \u201cDallas\u201d, \u201cPhiladelphia\u201d, \u201cLos Angeles\u201d, etc.) that will serve as the categories for every bar or bar group.\n    * A column (or multiple columns) with numeric values that will determine the height of each bar.\n\n*Note:* Each category may contain more than one bar -- for example, you can plot major Texas cities (as categories) and show separate bars for the number of barbecue restaurants and the number of steakhouses in each city.", "title": "Vertical bar chart"}, "embed": {"dimensions": {}}, "scripts": {"helper": "var werkHelper = {\n    parse: function(werk){\n        if (chartwerk.datamap.base === null) {\n            // If the chart doesn't have a base axis, raise an error.\n        } else {\n            // Otherwise, parse the data as passed.\n            werk.data = chartwerk.axes.color.domain.map(function(category){\n                return {\n                    name: category,\n                    values: chartwerk.data.map(function(d){\n                        return { x: d[chartwerk.datamap.base], y: d[category] };\n                    })\n                    .sort(function(a, b){ return d3.ascending(a.x, b.x); })\n                };\n            });\n        }\n    },\n    \n    dims: function(werk){\n        var s = chartwerk.ui.size;\n            w = werk.dims[s].width,\n            h = werk.dims[s].height,\n\n            margins = {\n                right: chartwerk.margins[s].right * w,\n                left: chartwerk.margins[s].left * w,\n                top: chartwerk.margins[s].top * h,\n                bottom: chartwerk.margins[s].bottom * h\n            },\n            svg = {\n                width: w - margins.left - margins.right,\n                height: h - margins.top - margins.bottom\n            };\n\n        werk.dims.margins = margins;\n        werk.dims.svg = svg;\n    },\n\n    scales: function(werk){\n        var svg = werk.dims.svg;\n\n        werk.scales = {\n            x0: d3.scaleBand()\n                    .rangeRound([0, svg.width]),\n            x1: d3.scaleBand()\n                    .padding(0.05),\n            y: d3.scaleLinear()\n                    .rangeRound([svg.height, 0]),\n            color: chartwerk.axes.color.range.length > 1 ? (\n                d3.scaleOrdinal()\n                  .domain(chartwerk.axes.color.domain)\n                  .range(chartwerk.axes.color.range)\n            ) : (\n                function(d) { return chartwerk.axes.color.range[0]; }\n            ),\n        };\n    },\n\n    baseDomain:  function(werk) {\n        var keys = chartwerk.axes.color.domain.sort();\n\n        werk.scales.x0.domain(\n            chartwerk.data.map(\n                function(dataPoint) { return dataPoint[chartwerk.datamap.base]; }\n            ).sort()\n        );\n        werk.scales.x1.domain(keys).rangeRound([0, werk.scales.x0.bandwidth()]);\n    },\n\n    valueDomain: function(werk) {\n        var keys = chartwerk.axes.color.domain.sort();\n\n        var useDefaultMin = (\n            (chartwerk.axes.value.min !== null) &&\n            (!isNaN(chartwerk.axes.value.min))\n        );\n\n        var dataMin = (useDefaultMin) ? (chartwerk.axes.value.min) : (\n            d3.min(chartwerk.data, function(d) {\n                return d3.min(keys, function(key) { return d[key]; });\n            })\n        );\n\n        if ((!useDefaultMin) && (dataMin > 0)) { dataMin = 0; }\n\n        var useDefaultMax = (\n            (chartwerk.axes.value.max !== null) &&\n            (!isNaN(chartwerk.axes.value.max))\n        );\n\n        var dataMax = (useDefaultMax) ? (chartwerk.axes.value.max) : (\n            d3.max(chartwerk.data, function(d) {\n                return d3.max(keys, function(key) { return d[key]; });\n            })\n        );\n\n        var extents = {\n            min: dataMin,\n            max: dataMax\n        };\n\n        werk.scales.y.domain([extents.min, extents.max]).nice();\n    },\n\n    axes: function(werk) {\n        werk.axes = {\n            x: d3.axisBottom(werk.scales.x0)\n                    .tickSizeInner(6)\n                    .tickSizeOuter(0)\n                    .tickPadding(3),\n\n            y: d3.axisLeft(werk.scales.y)\n                    .tickSizeInner(-werk.dims.svg.width)\n                    .tickSizeOuter(0)\n                    .tickPadding(7)\n                    .tickFormat( function(d){ \n                        var formatter = werk.scales.y.tickFormat();\n                        if (d >= 0) {\n                            return formatter(d) === '0' ? '0' : (\n                                chartwerk.axes.value.prefix +\n                                formatter(d) +\n                                chartwerk.axes.value.suffix\n                            );\n                        } else {\n                            return (\n                                '-' +\n                                chartwerk.axes.value.prefix +\n                                formatter(Math.abs(d)) +\n                                chartwerk.axes.value.suffix\n                            );\n                        }\n                    }),\n        };\n    },\n\n    valueTicks: function(werk){\n        var s = chartwerk.ui.size;\n\n        if (chartwerk.axes.value.format[s].customTicks.length > 0) { \n            werk.axes.y.tickValues(\n                chartwerk.axes.value.format[s].customTicks\n            );\n        } else {\n            hasTickConfig = (\n                chartwerk.axes.value.format[s].ticks !== null\n            ) && (\n                !isNaN(chartwerk.axes.value.format[s].ticks)\n            );\n\n            if (hasTickConfig) {\n                werk.axes.y.ticks(\n                    chartwerk.axes.value.format[s].ticks\n                );\n            }\n        }\n    },\n\n    highlightZero: function(werk) {\n        var keys = chartwerk.axes.color.domain.sort();\n\n        var dataMin = (\n            (chartwerk.axes.value.min !== null) &&\n            (!isNaN(chartwerk.axes.value.min))\n        ) ? (\n            chartwerk.axes.value.min\n        ) : (\n            d3.min(chartwerk.data, function(d) {\n                return d3.min(keys, function(key) { return d[key]; });\n            })\n        );\n\n        werk.highlightZeroLine = (dataMin < 0);\n    },\n\n    // Build dims, scales and axes.\n    build: function(werk){\n        this.parse(werk);\n        this.dims(werk);\n        this.scales(werk);\n        this.baseDomain(werk);\n        this.valueDomain(werk);\n        this.axes(werk);\n        this.valueTicks(werk);\n        this.highlightZero(werk);\n        return werk;\n    },\n};", "draw": "function draw() {\n\n    var initialProps = {\n        dims: {\n          single: { width: 260, height: 225 },\n          double: { width: 540, height: 250}\n        },\n    };\n    \n    // Returns object with properties and methods representing\n    // dimensions, scales, axes, etc.\n    var werk = werkHelper.build(initialProps);\n\n    var hasYAxisLabel = chartwerk.axes.value.label !== '';\n    var yAxisLabelHeight = 20;\n\n    var totalSvgHeight = hasYAxisLabel ? (\n        werk.dims.svg.height + yAxisLabelHeight\n    ) : (\n        werk.dims.svg.height\n    );\n\n    var svg = d3.select('#chart').append('svg')\n            .style('background-color', 'transparent')\n            .attr(\n                'width',\n                (\n                    werk.dims.margins.left +\n                    werk.dims.svg.width +\n                    werk.dims.margins.right\n                )\n            )\n            .attr(\n                'height',\n                (\n                    werk.dims.margins.top +\n                    totalSvgHeight +\n                    werk.dims.margins.bottom\n                )\n            );\n\n    var chartTop = hasYAxisLabel ? werk.dims.margins.top + yAxisLabelHeight : werk.dims.margins.top;\n\n    var g = svg.append('g')\n        .attr(\n            'transform',\n            'translate(' +\n                werk.dims.margins.left + ',' +\n                chartTop +\n            ')'\n        );\n\n    var xAxis = g.append('g')\n        .attr('class', 'x axis')\n        .attr('transform', 'translate(0,' + werk.dims.svg.height + ')')\n        .call(werk.axes.x);\n\n    var yAxis = g.append('g')\n            .attr('class', 'y axis')\n            .call(werk.axes.y);\n\n    if (chartwerk.ui.size === 'double') {\n        yAxis.attr('transform', 'translate(0,-1)');\n    }\n\n    if (hasYAxisLabel) {\n        yAxis.append('text')\n            .attr('class', 'label')\n            .attr('y', -werk.dims.margins.top + 15  - yAxisLabelHeight)\n            .attr('x', -werk.dims.margins.left)\n            .style('text-anchor', 'start')\n            .text(chartwerk.axes.value.label);\n    }\n\n    g.append('g')\n        .selectAll('g')\n        .data(chartwerk.data)\n        .enter().append('g')\n            .attr('class', function(d) {\n                return d[chartwerk.datamap.base].toLowerCase() + '-group';\n            })\n            .attr(\n                'transform',\n                function(d) {\n                    return (\n                        'translate(' +\n                        werk.scales.x0(d[chartwerk.datamap.base]) +\n                        ',0)'\n                    );\n                }\n            )\n        .selectAll('rect')\n        .data(\n            function(d) {\n                var keys = chartwerk.axes.color.domain.sort();\n\n                return keys.map(function(key) { return {key: key, value: d[key]}; });\n            }\n        )\n        .enter().append('rect')\n            .attr('x', function(d) { return werk.scales.x1(d.key); })\n            .attr('y', function(d) {\n                // \n                return (d.value >= 0) ? (werk.scales.y(d.value)) : (werk.scales.y(0));\n            })\n            .attr('width', werk.scales.x1.bandwidth())\n            .attr('height', function(d) {\n                return Math.abs(werk.scales.y(d.value) - werk.scales.y(0));\n                // return (\n                //     d.value >= 0\n                // ) ? (\n                //     werk.dims.svg.height - werk.scales.y(d.value)\n                // ) : (\n                //     werk.scales.\n                // );\n            })\n            .attr('fill', function(d) { return werk.scales.color(d.key); })\n            .attr('class', 'bar')\n            .style('pointer-events', 'fill')\n                .on('mouseout',  hideTooltip)\n                .on('mousemove', showTooltip);\n\n    if (werk.highlightZeroLine) {\n        g.append('line')\n            .attr('class', 'zero')\n            .attr('x1', 0)\n            .attr('x2', werk.dims.svg.width)\n            .attr('y1', werk.scales.y(0))\n            .attr('y2', werk.scales.y(0));\n    }\n\n    var tooltip = d3.select('#chart')\n      .append('div')\n        .attr('class', 'tooltip')\n        .style('position', 'absolute');\n\n    tooltip\n      .append('div')\n      .attr('class', 'value');\n\n    function showTooltip() {\n        var columnData = d3.select(this).datum();\n\n        var tooltipColor = werk.scales.color(columnData.key);\n\n        var comma = d3.format(',');\n\n        d3.select('.tooltip .value')\n          .style('color', tooltipColor)\n          .text(function(){\n              var v = chartwerk.axes.value;\n              return v.prefix + comma(columnData.value) + v.suffix;\n          });\n\n        var p = d3.mouse(this.parentElement.parentElement);\n\n        d3.select('.tooltip')\n            .style('opacity', 1)\n            .style('top', function(){\n                var s = chartwerk.ui.size;\n\n                var h = werk.dims[s].height;\n\n                var pos = p[1] > (h / 2) ? p[1] + 10 : p[1] + 20;\n\n                return pos.toString() + 'px';\n            })\n            .style(\"left\", function(){\n                // We position either left or right of the mouse point based\n                // on whether we're past the midpoint of the chart. This protects\n                // against tooltips overflowing embedded iframes.\n                var s = chartwerk.ui.size;\n\n                var w = werk.dims[s].width;\n\n                var tipW = parseInt(d3.select(\".tooltip\").style(\"width\"), 10);\n\n                var pos = p[0] > (w / 2) ? p[0] - (tipW - 20) : p[0] + 40;\n\n                return pos.toString() + \"px\";\n            });\n    }\n\n    function hideTooltip() {\n      d3.select(\".tooltip\").style(\"opacity\", 0);\n    }\n}", "styles": "#chartwerk {\n    font-family: 'Gotham A', 'Gotham B', arial, sans-serif; \n    width: 560px;\n}\n#chartwerk.single {\n    float: left;\n    margin: 10px 30px 10px 0;\n    overflow: hidden;\n    width: 270px;\n}\n#chartwerk #headline { \n    font-size: 24px;\n    font-weight: bold;\n}\n#chartwerk #chatter {\n    font-size: 14px;\n    line-height: 19px;\n    margin-bottom: 5px;\n    margin-top: 5px;\n}\n#chartwerk #footnote,\n#chartwerk #source,\n#chartwerk #author {\n    color: grey;\n    font-size: 11px;\n}\n#chartwerk #author {\n    text-align: right;\n}\n#chartwerk #chart {\n    background-color: white;\n}\n#chartwerk #chart-legend .chart-legend-container .key-label {\n    font: 11px 'Gotham A', 'Gotham B', arial, sans-serif;\n}\n#chartwerk #chart-legend .chart-legend-container .key-color {\n    margin-right: 2px;\n}\n#chartwerk #chart-legend .chart-legend-container .key {\n    margin-right: 8px;\n}\n#chartwerk .annotation p {\n    font-family: 'Gotham A', 'Gotham B', arial, sans-serif;\n}\n#chartwerk #chart .tooltip {\n    background: rgba(255,255,255,.75);\n    font: 13px 'Gotham A', 'Gotham B', arial, sans-serif;\n    opacity: 0;\n    padding: 5px;\n    pointer-events: none;\n    width: auto;\n}\n#chartwerk #chart .tooltip .value {\n    font-weight: bold;\n}\n#chartwerk #chart path.line {\n    fill: none;\n    stroke-width: 2px;\n}\n.axis path,\n.axis line {\n  fill: none;\n  shape-rendering: crispEdges;\n  stroke: rgb(180,180,180);\n}\n.axis text {\n    fill: rgb(132,132,132);\n    font-family: 'Gotham A', 'Gotham B', 'Montserrat', arial, sans-serif;\n    font-size: 11px;\n}\n.y.axis line {\n    stroke-dasharray: 3px 3px;\n}\n.y.axis path {\n    display:none;\n}\n.y.axis .label {\n    font-family: 'Gotham A', 'Gotham B', 'Montserrat', arial, sans-serif;\n    font-weight: normal;\n}\nrect.shaded-area{\n    fill: #DDDDDD;\n}\nline.zero {\n    stroke: #000000;\n    stroke-width: 1px;\n}", "dependencies": {"styles": ["https://cloud.typography.com/6922714/7642152/css/fonts.css", "https://interactives.dallasnews.com/common/fonts/gotham.css"], "scripts": ["https://cdnjs.cloudflare.com/ajax/libs/d3/4.2.3/d3.min.js"]}, "html": "<div id='chart-header'>\n\t<h2 id='headline'></h2>\n\t<div id='chatter'></div> \n</div> \n<div id='chart-ui'>\n\t<!--You can put any necessary buttons, etc., here.-->\n</div>\n<div id='chart-legend'></div>\n<div id='chart'></div> \n<div id='chart-footer'> \n\t<div id='footnote'></div> \n\t<div id='source'></div> \n\t<div id='author'></div> \n</div>"}, "datamap": {"value": null, "custom": {}, "ignore": [], "scale": null, "series": ["Letter count", "Abbreviated"], "sort": ["State", "Letter count", "Abbreviated"], "facet": null, "base": "State"}, "axes": {"color": {"ignoreScale": false, "domain": ["Abbreviated", "Letter count"], "byFacet": false, "quantizeProps": {"reverseColors": false, "groups": 0, "column": null}, "scheme": "categorical.default", "quantize": false, "range": ["#E34E36", "#329CEB"]}, "value": {"prefix": "", "suffix": "", "min": 0, "shadedRegions": [], "label": "Letter counts", "max": 10, "format": {"single": {"customTicks": [], "ticks": 7}, "double": {"customTicks": [], "ticks": 7}}}, "scale": {"prefix": "", "suffix": ""}, "base": {"prefix": "", "type": "categorical", "suffix": "", "min": null, "shadedRegions": [], "label": "", "max": null, "dateFormat": null, "format": {"single": {"customTicks": [], "dateString": "Y", "ticks": 7, "frequency": 2}, "double": {"customTicks": [], "dateString": "Y", "ticks": 7, "frequency": 1}}}}, "ui": {"size": "single", "rawData": "State\tLetter count\tAbbreviated\nVirginia\t8\t3\nMissouri\t8\t3\nIowa\t4\t4\nTexas\t5\t5", "datamap": [{"available": true, "class": "base", "alias": "Category"}, {"available": true, "class": "value", "alias": "Single value"}, {"available": false, "class": "scale", "alias": "scale axis"}, {"available": true, "class": "series", "alias": "Grouped value"}, {"available": false, "class": "facet", "alias": "faceting column"}, {"available": true, "class": "ignore", "alias": "Ignored column"}]}, "margins": {"single": {"left": 0.11, "top": 0.05, "right": 0.020000000000000018, "bottom": 0.10999999999999999}, "double": {"left": 0.06, "top": 0.05, "right": 0.020000000000000018, "bottom": 0.07999999999999996}}, "data": [{"Abbreviated": 3, "State": "Virginia", "Letter count": 8}, {"Abbreviated": 3, "State": "Missouri", "Letter count": 8}, {"Abbreviated": 4, "State": "Iowa", "Letter count": 4}, {"Abbreviated": 5, "State": "Texas", "Letter count": 5}]}, "created": "2017-05-25T01:26:04.017Z", "updated": "2017-05-25T01:26:04.020Z", "author": null, "creator": null, "icon": "", "description": null}}, {"model": "chartwerk.template", "pk": 9, "fields": {"slug": "unit-chart", "title": "unit-chart", "data": {"text": {"chatter": null, "annotations": [], "source": "Dallas Morning News analysis", "legend": {"single": {"inside": false, "position": {"x": 10, "y": 10}, "align": "l", "background": true, "width": 250}, "double": {"inside": false, "position": {"x": 10, "y": 10}, "align": "l", "background": true, "width": 500}, "title": "", "active": true, "keys": [{"text": "A", "color": "#E34E36"}, {"text": "J", "color": "#329CEB"}, {"text": "Other", "color": "#C9C9C9"}]}, "author": "John Doe", "headline": "First letter for interactives team first names", "title": "", "footnote": null}, "template": {"icon": null, "tags": [], "description": null, "title": "Unit chart"}, "embed": {"dimensions": {}}, "scripts": {"helper": "var werkHelper = {\n    dims: function(werk){\n        var s = chartwerk.ui.size;\n            w = werk.dims[s].width,\n            h = werk.dims[s].height,\n            margins = {\n                right: chartwerk.margins[s].right * w,\n                left: chartwerk.margins[s].left * w,\n                top: chartwerk.margins[s].top * h,\n                bottom: chartwerk.margins[s].bottom * h\n            },\n            svg = {\n                width: w - margins.left - margins.right,\n                height: h + 2 - margins.top - margins.bottom\n            };\n        \n        werk.dims.margins = margins;\n        werk.dims.svg = svg;\n    },\n    \n    scales: function(werk){\n        var svg = werk.dims.svg;\n        werk.scales = {\n            color: chartwerk.axes.color.quantize ? \n                d3.scaleQuantize() : d3.scaleOrdinal(),\n        };\n        \n        werk.scales.color\n            .domain(chartwerk.axes.color.domain)\n            .range(chartwerk.axes.color.range);\n    },\n\n    // Build dims, scales and axes.\n    build: function(werk){\n        this.dims(werk);\n        this.scales(werk);\n        return werk;\n    },\n};", "draw": "function draw(){\n\n    var size = chartwerk.ui.size;\n\n    var VALUE_KEY = chartwerk.datamap.value;\n    var UNIT_SPACING = 4;\n    var UNITS_PER_ROW = size === 'double' ? 18 : 12;\n    var CHART_WIDTH = size === 'double' ? 580 : 270;\n    \n    var unitSize = ((CHART_WIDTH) / UNITS_PER_ROW) - UNIT_SPACING;\n    var totalUnits = chartwerk.data.reduce(function(m, d) {\n        return m + d[VALUE_KEY];\n    }, 0);\n    \n    var chartHeight = Math.ceil(totalUnits / UNITS_PER_ROW) * (UNIT_SPACING + unitSize);\n\n    var werk = werkHelper.build({\n        dims: {\n          single: {\n            width: CHART_WIDTH,\n            height: chartHeight\n          },\n          double: {\n            width: CHART_WIDTH,\n            height: chartHeight\n          }\n        }\n    });\n\n    var svg = d3.select('#chart')\n        .append('svg')\n        .attr('width', werk.dims.svg.width + werk.dims.margins.left + werk.dims.margins.right)\n        .attr('height', werk.dims.svg.height + werk.dims.margins.top + werk.dims.margins.bottom)\n      .append('g')\n        .attr('transform', 'translate(' + werk.dims.margins.left + ',' + werk.dims.margins.top + ')');\n\n    var i = 0;\n    var data = chartwerk.data.map(function(d) {\n      return d3.range(d[VALUE_KEY]).map(function() {\n        var e = JSON.parse(JSON.stringify(d));\n        e.idx = i++;\n        return e;\n      });\n    });\n    \n    var facets = svg.selectAll('.facet')\n      .data(data)\n      .enter().append('g')\n      .attr('class', 'facet');\n    \n    facets.selectAll('.unit')\n      .data(function(d) {\n        return d;\n      })\n      .enter()\n      .append('rect')\n      .attr('class', 'unit')\n      .attr('width', unitSize)\n      .attr('height', unitSize)\n      .attr('fill', function(d) {\n        return werk.scales.color(d[chartwerk.datamap.scale]);\n      })\n      .attr('x', function(d) {\n        return d.idx % UNITS_PER_ROW * (unitSize + UNIT_SPACING);\n      })\n      .attr('y', function(d) {\n        return Math.floor(d.idx / UNITS_PER_ROW) * (unitSize + UNIT_SPACING);\n      });\n\n  facets\n    .on('mouseover', function(d) {\n      d3.select(this).classed('highlight', true);\n      d3.select('.tooltip .title').text(d[0][chartwerk.datamap.scale]);\n      d3.select('.tooltip .value').text(d[0][VALUE_KEY]);\n    })\n    .on('mouseout', function(d) {\n      d3.select(this).classed('highlight', false);\n    });\n\n    var tooltip = d3.select(\"#chart\")\n      .append(\"div\")\n        .attr(\"class\",\"tooltip\")\n        .style(\"position\",\"absolute\");\n    tooltip\n      .append(\"div\")\n      .attr(\"class\",\"title\")\n      .text(chartwerk.datamap.scale);\n    tooltip\n      .append(\"div\")\n      .attr(\"class\",\"value\");\n}", "styles": "\n#chartwerk {\n    font-family:'Gotham A', 'Gotham B', arial, sans-serif; \n    width:600px;\n}\n#chartwerk.single{\n    width:290px;\n    float:left;\n    overflow:hidden;\n    margin:10px 30px 10px 0;\n}\n#chartwerk #headline { \n    font-weight:bold;\n    font-size:24px;\n}\n#chartwerk #chatter {\n    margin-top:5px;\n}\n#chartwerk #footnote,\n#chartwerk #source,\n#chartwerk #author {\n    font-size:11px;\n    color:grey;\n\n}\n#chartwerk #author {\n    text-align:right;\n}\n#chartwerk #chart{\n    background-color:white;\n}\n#chartwerk #chart-legend \n.chart-legend-container .key-label{\n    font:11px 'Gotham A', 'Gotham B', arial, sans-serif;\n}\n#chartwerk #chart-legend \n.chart-legend-container .key-color{\n    margin-right:2px;\n}\n#chartwerk #chart-legend \n.chart-legend-container .key{\n    margin-right:8px;\n}\n#chartwerk .annotation p{\n    font-family:'Gotham A', 'Gotham B', arial, sans-serif;\n}\n#chartwerk #chart .tooltip{\n    font: 13px 'Gotham A', 'Gotham B', arial, sans-serif;\n    opacity:0;\n    pointer-events:none;\n    background:rgba(255,255,255,.75);\n    padding:5px;\n    width:auto;\n}\n#chartwerk #chart .tooltip .title{\n    font-weight: bold;\n    fill:grey;\n}\n.facet.highlight {\n    stroke: #000;\n}", "dependencies": {"styles": ["https://cloud.typography.com/6922714/7642152/css/fonts.css", "https://interactives.dallasnews.com/common/fonts/gotham.css"], "scripts": ["https://cdnjs.cloudflare.com/ajax/libs/d3/4.2.3/d3.min.js"]}, "html": "<div id='chart-header'>\n\t<h2 id='headline'></h2>\n\t<div id='chatter'></div> \n</div> \n<div id='chart-ui'>\n\t<!--You can put any necessary buttons, etc., here.-->\n</div>\n<div id='chart-legend'></div>\n<div id='chart'></div> \n<div id='chart-footer'> \n\t<div id='footnote'></div> \n\t<div id='source'></div> \n\t<div id='author'></div> \n</div>"}, "datamap": {"value": "Number", "custom": {}, "ignore": [], "scale": "County", "series": [], "sort": [], "facet": null, "annotations": [], "base": null}, "axes": {"color": {"ignoreScale": false, "domain": ["A", "J", "Other"], "byFacet": true, "quantizeProps": {"reverseColors": false, "groups": 0, "column": null}, "scheme": "categorical.default", "quantize": false, "range": ["#E34E36", "#329CEB", "#C9C9C9"]}, "value": {"prefix": "$", "suffix": "", "min": null, "shadedRegions": [], "label": "Dollars", "max": null, "format": {"single": {"customTicks": [], "ticks": 7}, "double": {"customTicks": [], "ticks": 7}}}, "scale": {"prefix": "", "suffix": ""}, "base": {"prefix": "", "type": "categorical", "suffix": "", "min": null, "shadedRegions": [], "label": "", "max": null, "dateFormat": null, "format": {"single": {"customTicks": [], "dateString": "Y", "ticks": 7, "frequency": 2}, "double": {"customTicks": [], "dateString": "Y", "ticks": 7, "frequency": 1}}}}, "ui": {"size": "double", "rawData": "County\tNumber\nA\t30\nJ\t20\nOther\t30", "datamap": [{"available": false, "class": "base", "alias": "base axis"}, {"available": true, "class": "value", "alias": "Value"}, {"available": true, "class": "scale", "alias": "Color group"}, {"available": false, "class": "series", "alias": "data series"}, {"available": false, "class": "facet", "alias": "faceting column"}, {"available": false, "class": "ignore", "alias": "ignored column"}]}, "margins": {"single": {"left": 0, "top": 0, "right": 0, "bottom": 0}, "double": {"left": 0, "top": 0, "right": 0, "bottom": 0}}, "data": [{"County": "A", "Number": 30}, {"County": "J", "Number": 20}, {"County": "Other", "Number": 30}]}, "created": "2017-05-25T01:26:43.204Z", "updated": "2017-05-25T01:26:43.206Z", "author": null, "creator": null, "icon": "", "description": null}}, {"model": "chartwerk.template", "pk": 10, "fields": {"slug": "data-table", "title": "data-table", "data": {"text": {"chatter": "These are some made up numbers about all these places.", "annotations": [], "source": "SOURCE: Wiki", "legend": {"single": {"inside": false, "position": {"x": 10, "y": 10}, "align": "l", "background": true, "width": 250}, "double": {"inside": false, "position": {"x": 10, "y": 10}, "align": "l", "background": true, "width": 500}, "title": "", "active": false, "keys": []}, "author": "Jane Doe / DMN", "headline": "A tale of twelve cities", "title": "", "footnote": ""}, "template": {"icon": null, "tags": [], "description": "Use this template to create a basic table.\n\nJust paste your table in; none of the usual chart configuration is required for this template.", "title": "Data table"}, "embed": {"dimensions": {}}, "scripts": {"helper": "var werkHelper = {};", "draw": "function draw(){\n\n    var keys = chartwerk.datamap.sort;\n    \n    var table = d3.select(\"#chart\")\n        .append(\"div\")\n        .attr(\"id\",\"table\")\n        .append(\"table\");\n    \n    var thead = table.append(\"thead\");\n    \n    keys.forEach(function(k){\n        thead.append(\"th\")\n            .attr(\"class\", \"sort\")\n            .attr(\"data-sort\", k)\n            .text(k);\n    });\n    \n    var tbody = table.append(\"tbody\")\n            .attr(\"class\", \"list\");\n    \n    chartwerk.data.forEach(function(d){\n        var tr = tbody.append(\"tr\");\n        keys.forEach(function(k){\n            tr.append(\"td\")\n                .attr(\"class\", \"td \"+ k)\n                .text(d[k]);\n        });\n    });\n    \n    var tableOptions = {\n      valueNames: keys\n    };\n\n    var tableList = new List('table', tableOptions);\n    \n    // List\n    \n    var list = d3.select(\"#chart\")\n        .append(\"div\")\n        .attr(\"id\",\"list\")\n        .attr(\"class\",\"hidden\");\n    \n    list.append(\"ul\")\n        .attr(\"class\", \"list\");\n    \n    paras = keys.map(function(k){\n        return '<p><span class=\"list-hed\">'+k+'</span> <span class=\"'+k+'\"></span></p>';\n    }).join('');\n    \n    var listOptions = {\n      valueNames: keys,\n      item: '<li>'+paras+'</li>'\n    };\n    \n    var listList = new List('list', listOptions, chartwerk.data);\n    \n    function switchStyle(){\n        if($(\"#chart\").width() < $(\"#table\")[0].scrollWidth){\n            $(\"#table\").addClass(\"hidden\");\n            $(\"#list\").removeClass(\"hidden\");\n        }\n    }\n    setTimeout(function(){\n        switchStyle();\n    }, 100);\n    \n\n}", "styles": "#chartwerk {\n    width:560px;\n}\n#chartwerk div, #chartwerk p{\n    font-family:'Gotham A', 'Gotham B', arial, sans-serif;\n}\n#chartwerk.single{\n    width:270px;\n    float:left;\n    overflow:hidden;\n    margin:10px 30px 10px 0;\n}\n#chartwerk #headline { \n    font-weight:bold;\n    font-size:24px;\n}\n#chartwerk #chatter {\n    margin-top:5px;\n    font-size:14px;\n    line-height:19px;\n}\n#chartwerk #footnote,\n#chartwerk #source,\n#chartwerk #author {\n    font-size:11px;\n    color:grey;\n\n}\n#chartwerk #author {\n    text-align:right;\n}\n#chartwerk #chart{\n    background-color:white;\n}\n#chartwerk table{\n    margin:10px 0 20px;\n    overflow-x:visible;\n    text-align:left;\n    width:100%;\n}\n#chartwerk table th, #chartwerk table td{\n    padding:2px 10px 2px 5px;\n    \n}\n#chartwerk table th{\n    border-bottom:2px solid grey;\n    cursor:pointer;\n    vertical-align: bottom;\n}\n#chartwerk table th:hover{\n    background-color:lightgrey;\n}\n#chartwerk table tbody tr:first-child td{\n    padding-top:10px;\n}\n#chartwerk table tbody tr{\n    border-bottom:1px solid lightgrey;\n}\n#chartwerk table tr:hover{\n    background-color:#ccc !important;\n}\n#chartwerk #list{\n    margin:10px 0 20px;\n    max-height:300px;\n    overflow-y:scroll;\n}\n#chartwerk #list li{\n    border-bottom:1px solid lightgrey;\n    padding: 5px 0;\n}\n\n#chartwerk #list p{\n    text-align:left;\n    margin:1px 0;\n    line-height:12px;\n    padding:2px;\n    font-size:12px;\n}\n#chartwerk #list p span.list-hed{\n    font-size:10px;\n    color:grey;\n    display:inline-block;\n    width:25%;\n    word-wrap: normal;\n    line-height:12px;\n}\n::-webkit-scrollbar{\n  width: 6px;\n}\n\n::-webkit-scrollbar-track{\n  background: rgba(0, 0, 0, 0.1);\n  border-radius:5px;\n}\n\n::-webkit-scrollbar-thumb{\n  background: rgba(0, 0, 0, 0.4);\n  border-radius:5px;\n}\n.hidden{\n    display:none !important;\n}", "dependencies": {"styles": ["https://cloud.typography.com/6922714/7642152/css/fonts.css", "https://interactives.dallasnews.com/common/fonts/gotham.css"], "scripts": ["https://cdnjs.cloudflare.com/ajax/libs/d3/4.2.3/d3.min.js", "https://cdnjs.cloudflare.com/ajax/libs/list.js/1.2.0/list.min.js"]}, "html": "<div id='chart-header'>\n\t<h2 id='headline'></h2>\n\t<div id='chatter'></div> \n</div> \n<div id='chart-ui'>\n\t<!--You can put any necessary buttons, etc., here.-->\n</div>\n<div id='chart-legend'></div>\n<div id='chart'></div> \n<div id='chart-footer'> \n\t<div id='footnote'></div> \n\t<div id='source'></div> \n\t<div id='author'></div> \n</div>"}, "datamap": {"value": null, "custom": {}, "ignore": [], "scale": null, "series": [], "sort": ["City", "Country", "Numbers", "More", "Another"], "facet": null, "annotations": [], "base": null}, "axes": {"color": {"ignoreScale": false, "domain": [], "byFacet": false, "quantizeProps": {"reverseColors": false, "groups": 0, "column": null}, "scheme": "categorical.default", "quantize": false, "range": []}, "value": {"prefix": "", "suffix": "%", "min": null, "shadedRegions": [], "label": "", "max": null, "format": {"single": {"customTicks": [], "ticks": 7}, "double": {"customTicks": [], "ticks": 7}}}, "scale": {"prefix": "", "suffix": ""}, "base": {"prefix": "", "type": "categorical", "suffix": "", "min": null, "shadedRegions": [], "label": "", "max": null, "dateFormat": null, "format": {"single": {"customTicks": [], "dateString": "Y", "ticks": 7, "frequency": 2}, "double": {"customTicks": [], "dateString": "Y", "ticks": 7, "frequency": 1}}}}, "ui": {"size": "double", "rawData": "City\tCountry\tNumbers\tMore\tAnother\nAsheville\tUS\t12\t14\t234\nBoston\tUS\t11\t11.12\t334\nBelfast\tUK\t9\t7\t124\nLos Angeles\tUS\t7\t3.45\t151\nNew York\tUS\t7\t6.77\t323\nDallas\tUS\t6\t4\t272\nDenver\tUS\t2\t8\t234\nLondon\tUK\t-3\t10.22\t334\nKansas City\tUS\t-4\t16.66\t124\nBerlin\tDE\t-7\t13\t123\nLisbon\tPT\t-10\t41.11\t412\nHelsinki\tFI\t-12\t14.3\t311\n", "datamap": [{"available": true, "class": "base", "alias": "base axis"}, {"available": true, "class": "value", "alias": "value axis"}, {"available": true, "class": "scale", "alias": "scale axis"}, {"available": true, "class": "series", "alias": "data series"}, {"available": true, "class": "facet", "alias": "faceting column"}, {"available": true, "class": "ignore", "alias": "ignored column"}]}, "margins": {"single": {"left": 0, "top": 0.03, "right": 0, "bottom": 0.040000000000000036}, "double": {"left": 0, "top": 0.03, "right": 0, "bottom": 0.040000000000000036}}, "data": [{"Country": "US", "Numbers": 12, "Another": 234, "More": 14, "City": "Asheville"}, {"Country": "US", "Numbers": 11, "Another": 334, "More": 11.12, "City": "Boston"}, {"Country": "UK", "Numbers": 9, "Another": 124, "More": 7, "City": "Belfast"}, {"Country": "US", "Numbers": 7, "Another": 151, "More": 3.45, "City": "Los Angeles"}, {"Country": "US", "Numbers": 7, "Another": 323, "More": 6.77, "City": "New York"}, {"Country": "US", "Numbers": 6, "Another": 272, "More": 4, "City": "Dallas"}, {"Country": "US", "Numbers": 2, "Another": 234, "More": 8, "City": "Denver"}, {"Country": "UK", "Numbers": -3, "Another": 334, "More": 10.22, "City": "London"}, {"Country": "US", "Numbers": -4, "Another": 124, "More": 16.66, "City": "Kansas City"}, {"Country": "DE", "Numbers": -7, "Another": 123, "More": 13, "City": "Berlin"}, {"Country": "PT", "Numbers": -10, "Another": 412, "More": 41.11, "City": "Lisbon"}, {"Country": "FI", "Numbers": -12, "Another": 311, "More": 14.3, "City": "Helsinki"}]}, "created": "2017-05-25T01:27:32.715Z", "updated": "2017-05-25T01:27:32.718Z", "author": null, "creator": null, "icon": "", "description": null}}, {"model": "chartwerk.template", "pk": 11, "fields": {"slug": "horizontal-bar-chart", "title": "horizontal-bar-chart", "data": {"text": {"chatter": "Some states even have more letters in their names than some others.", "annotations": [], "source": "SOURCE: Pew Research", "legend": {"single": {"inside": false, "position": {"x": 10, "y": 10}, "align": "l", "background": true, "width": 250}, "double": {"inside": false, "position": {"x": 10, "y": 10}, "align": "l", "background": true, "width": 500}, "title": "", "active": false, "keys": []}, "author": "Jane Doe / DMN", "headline": "States have names", "title": "", "footnote": ""}, "template": {"icon": null, "tags": [], "description": "Use horizontal bar charts when you want to show comparisons of quantity. Examples include population by city, touchdowns by player or sales by vehicle model.\n\nAs a general rule, horizontal bar charts should not be used to show trends over time, for example, how many homes are purchased each year. Use a line chart instead.\n\nYour data should contain two columns:\n\n* One with the categorical labels, like \"Dallas\", \"Philadelphia\", \"Los Angeles\", etc.\n* And another that contains the numeric values that will determine the width of the bars. ", "title": "Horizontal bar chart"}, "embed": {"dimensions": {}}, "scripts": {"helper": "var werkHelper = {\n    parse: function(werk){\n        \n        werk.data = chartwerk.data.map(function(d){\n            return {\n                name: d[chartwerk.datamap.base].toString(),\n                value: d[chartwerk.datamap.value]\n            };\n        });\n    },\n    \n    dims: function(werk){\n        var s = chartwerk.ui.size;\n            w = werk.dims[s].width,\n            h = werk.dims[s].height,\n            // Add a little extra left margin to accomondate labels\n            maxLen = d3.max(werk.data, function(d){ return d.name.length; })\n            margins = {\n                right: chartwerk.margins[s].right * w,\n                left: chartwerk.margins[s].left * w + (maxLen * 4),\n                top: chartwerk.margins[s].top * h,\n                bottom: chartwerk.margins[s].bottom * h\n            },\n            div = {\n                width: w - margins.left - margins.right,\n                height: h - margins.top - margins.bottom\n            };\n            console.log(maxLen);\n        \n        \n        werk.dims.margins = margins;\n        werk.dims.div = div;\n    },\n\n    scales: function(werk){\n        var div = werk.dims.div;\n        werk.scales = {\n            x: d3.scaleLinear()\n                .range([0, div.width]),\n        };\n    },\n    \n\n    valueDomain: function(werk){\n        var max = d3.max(werk.data, function(d) { \n                return d.value; \n            });\n        \n        if (chartwerk.axes.value.min && chartwerk.axes.value.max) {\n            werk.scales.x.domain(\n                [chartwerk.axes.value.min, chartwerk.axes.value.max]\n            );\n        } else if (chartwerk.axes.value.min) {\n            werk.scales.x.domain(\n                [chartwerk.axes.value.min, max ]\n            );\n        } else if (chartwerk.axes.value.max) {\n            werk.scales.x.domain(\n                [0, chartwerk.axes.value.max]\n            );\n        } else {\n            werk.scales.x.domain([0, max]);\n        }\n        \n        werk.scales.x.nice();\n    },\n\n\n    // Build dims, scales and axes.\n    build: function(werk){\n        this.parse(werk);\n        this.dims(werk);\n        this.scales(werk);\n        this.valueDomain(werk);\n        return werk;\n    },\n};", "draw": "function draw(){\n\n    var initialProps = {\n        dims: {\n          single: { width: 260, height: 225 },\n          double: { width: 540, height: 250}\n        },\n    };\n    \n    // Returns object with properties and methods representing\n    // dimensions, scales, axes, etc.\n    var werk = werkHelper.build(initialProps);\n    \n    var comma = d3.format(\",\");\n    \n    var div = d3.select(\"#chart\")\n        .append(\"div\")\n        .style(\"margin\", \n            werk.dims.margins.top + \"px \" +\n            werk.dims.margins.right + \"px \" +\n            werk.dims.margins.bottom + \"px \" +\n            werk.dims.margins.left + \"px \"\n        );\n    \n    \n    var response = div.selectAll(\".response\")\n        .data(werk.data)\n      .enter().append(\"div\")\n        .attr(\"class\",\"response\");\n    \n    var bar = response.append(\"div\")\n        .attr(\"class\", \"bar\")\n        .style(\"background-color\", chartwerk.axes.color.range[0])\n        .style(\"width\", function(d){ return werk.scales.x(d.value) + 'px'; });\n    \n    bar.append(\"div\")\n        .attr(\"class\",\"name label\")\n      .append(\"p\")\n        .text(function(d){ return d.name;});\n        \n    bar.append(\"div\")\n        .attr(\"class\",\"value label\")\n      .append(\"p\")\n        .attr(\"class\", function(d){\n            return werk.scales.x(d.value) < 75 ?\n                'offset' : '';\n        })\n        .style(\"width\", function(d){\n            return werk.scales.x(d.value) < 75 ?\n                werk.dims.div.width - this.parentElement.parentElement.clientWidth + 'px' : '';\n        })\n        .style(\"margin-left\", function(d){\n            return werk.scales.x(d.value) < 75 ?\n                this.parentElement.parentElement.clientWidth + 'px' : '';\n        })\n        .text(function(d){\n            return chartwerk.axes.value.prefix + comma(String(d.value)) + chartwerk.axes.value.suffix;\n        });\n    \n\n}", "styles": "#chartwerk {\n    width:560px;\n}\n#chartwerk div{\n    font-family:'Gotham A', 'Gotham B', arial, sans-serif; \n}\n#chartwerk.single{\n    width:270px;\n    float:left;\n    overflow:hidden;\n    margin:10px 30px 10px 0;\n}\n#chartwerk #headline { \n    font-weight:bold;\n    font-size:24px;\n}\n#chartwerk #chatter {\n    margin-top:5px;\n    font-size:14px;\n    line-height:19px;\n}\n#chartwerk #footnote,\n#chartwerk #source,\n#chartwerk #author {\n    font-size:11px;\n    color:grey;\n\n}\n#chartwerk #author {\n    text-align:right;\n}\n#chartwerk #chart{\n    background-color:white;\n}\n#chartwerk .response{\n    margin-top:5px;\n}\n#chartwerk .response p{\n    font: 13px/16px 'Gotham A', 'Gotham B', arial, sans-serif;\n}\n#chartwerk #chart .bar{\n    height:24px;\n    display:inline-block;\n}\n#chartwerk #chart .bar .label{\n    width:100%;\n    text-align:right;\n}\n#chartwerk #chart .bar .name.label{\n    width:100%;\n    text-align:right;\n    padding:5px 5px 0 0;\n    margin-left:-100%;\n    position:absolute;\n    color:#666;\n}\n#chartwerk #chart .bar .value.label p{\n    padding-right:5px;\n    padding-top:4px;\n    font-weight:bold;\n    font-size:14px;\n    line-height:18px;\n    color:#fff;\n}\n#chartwerk #chart .bar .value.label p.offset{\n    text-align:left;\n    padding-left:3px;\n    color:#666;\n}", "dependencies": {"styles": ["https://cloud.typography.com/6922714/7642152/css/fonts.css", "https://interactives.dallasnews.com/common/fonts/gotham.css"], "scripts": ["https://cdnjs.cloudflare.com/ajax/libs/d3/4.2.3/d3.min.js"]}, "html": "<div id='chart-header'>\n\t<h2 id='headline'></h2>\n\t<div id='chatter'></div> \n</div> \n<div id='chart-ui'>\n\t<!--You can put any necessary buttons, etc., here.-->\n</div>\n<div id='chart-legend'></div>\n<div id='chart'></div> \n<div id='chart-footer'> \n\t<div id='footnote'></div> \n\t<div id='source'></div> \n\t<div id='author'></div> \n</div>"}, "datamap": {"value": "Numbers", "custom": {}, "ignore": [], "scale": null, "series": [], "sort": [], "facet": null, "annotations": [], "base": "State"}, "axes": {"color": {"ignoreScale": false, "domain": ["Numbers"], "byFacet": false, "quantizeProps": {"reverseColors": false, "groups": 0, "column": null}, "scheme": "categorical.default", "quantize": false, "range": ["#329CEB"]}, "value": {"prefix": "", "suffix": "", "min": null, "shadedRegions": [], "label": "", "max": null, "format": {"single": {"customTicks": [], "ticks": 7}, "double": {"customTicks": [], "ticks": 7}}}, "scale": {"prefix": "", "suffix": ""}, "base": {"prefix": "", "type": "categorical", "suffix": "", "min": null, "shadedRegions": [], "label": "", "max": null, "dateFormat": null, "format": {"single": {"customTicks": [], "dateString": "Y", "ticks": 7, "frequency": 2}, "double": {"customTicks": [], "dateString": "Y", "ticks": 7, "frequency": 1}}}}, "ui": {"size": "single", "rawData": "State\tNumbers\nKentucky\t8\nMassachusetts\t13\nArizona\t7\nMissouri\t8\nCalifornia\t10\nNew York\t8\nTexas\t5\n", "datamap": [{"available": true, "class": "base", "alias": "Category"}, {"available": true, "class": "value", "alias": "Value"}, {"available": false, "class": "scale", "alias": "scale axis"}, {"available": false, "class": "series", "alias": "data series"}, {"available": false, "class": "facet", "alias": "faceting column"}, {"available": false, "class": "ignore", "alias": "ignored column"}]}, "margins": {"single": {"left": 0.19, "top": 0.04, "right": 0, "bottom": 0.040000000000000036}, "double": {"left": 0.09, "top": 0.04, "right": 0, "bottom": 0.040000000000000036}}, "data": [{"State": "Kentucky", "Numbers": 8}, {"State": "Massachusetts", "Numbers": 13}, {"State": "Arizona", "Numbers": 7}, {"State": "Missouri", "Numbers": 8}, {"State": "California", "Numbers": 10}, {"State": "New York", "Numbers": 8}, {"State": "Texas", "Numbers": 5}]}, "created": "2017-05-25T01:28:21.651Z", "updated": "2017-05-25T01:28:21.655Z", "author": null, "creator": null, "icon": "", "description": null}}]
+[{
+  "model": "chartwerk.template",
+  "pk": 5,
+  "fields": {
+    "slug": "line-chart",
+    "title": "Line chart",
+    "data": {
+      "text": {
+        "chatter": "Rising faster than expected, industry rebounds.",
+        "annotations": [],
+        "source": "SOURCE: New York Stock Exchange",
+        "legend": {
+          "single": {
+            "inside": false,
+            "position": {
+              "x": 10,
+              "y": 10
+            },
+            "align": "l",
+            "background": true,
+            "width": 250
+          },
+          "double": {
+            "inside": false,
+            "position": {
+              "x": 10,
+              "y": 10
+            },
+            "align": "l",
+            "background": true,
+            "width": 500
+          },
+          "title": "",
+          "active": true,
+          "keys": [{
+            "text": "CBM",
+            "color": "#329CEB"
+          }, {
+            "text": "GQS",
+            "color": "#E34E36"
+          }]
+        },
+        "author": "John Doe / DMN",
+        "headline": "Stock prices rise",
+        "title": "",
+        "footnote": ""
+      },
+      "template": {
+        "icon": null,
+        "tags": [],
+        "description": "Line charts are used to show continuous data over time. Examples include stock prices, temperatures, indexes and rates.\n\nThe X axis (base axis) on a line chart always runs along a date range, for example, 1992 to 2012. \n\nYour data should include one column of dates. Check out the available date formats on the Axes tab, and format your dates in your spreadsheet according to one of these.\n\nYou should have one column of data for each line in your chart.",
+        "title": "Line chart"
+      },
+      "embed": {
+        "dimensions": {}
+      },
+      "scripts": {
+        "helper": "var werkHelper = {\n    parse: function(werk){\n        werk.parsers = {\n          base: d3.timeParse( chartwerk.axes.base.dateFormat ),\n          value: function(d){ return d === '' ? NaN : +d; }\n        };\n        \n        werk.data = chartwerk.axes.color.domain.map(function(category){\n            return {\n                name: category,\n                values: chartwerk.data.map(function(d){\n                    return {\n                        x: werk.parsers.base(\n                            String(d[chartwerk.datamap.base])\n                        ),\n                        y: werk.parsers.value(d[category])\n                    };\n                })\n                .sort(function(a, b){ return d3.ascending(a.x, b.x); })\n            };\n        });\n        \n        // Get max and min of data \n        var xMax = d3.max(werk.data,function(series){return d3.max(series.values,function(d){return d.x; }); }),\n\t        xMin = d3.min(werk.data,function(series){return d3.min(series.values,function(d){return d.x; }); }),\n\t        yMax = d3.max(werk.data,function(series){return d3.max(series.values,function(d){return d.y; }); }),\n\t        yMin = d3.min(werk.data,function(series){return d3.min(series.values,function(d){return d.y; }); });\n        \n        werk.dataDims = {\n            xMin: xMin,\n            xMax: xMax,\n            yMin: yMin,\n            yMax: yMax\n        };\n    },\n    \n    dims: function(werk){\n        var s = chartwerk.ui.size;\n            w = werk.dims[s].width,\n            h = werk.dims[s].height,\n            margins = {\n                right: chartwerk.margins[s].right * w,\n                left: chartwerk.margins[s].left * w,\n                top: chartwerk.margins[s].top * h,\n                bottom: chartwerk.margins[s].bottom * h\n            },\n            svg = {\n                width: w - margins.left - margins.right,\n                height: h - margins.top - margins.bottom\n            };\n        \n        werk.dims.margins = margins;\n        werk.dims.svg = svg;\n    },\n\n    scales: function(werk){\n        var svg = werk.dims.svg;\n        werk.scales = {\n            x: d3.scaleTime()\n                .range([0, svg.width]),\n            y: d3.scaleLinear()\n                .range([svg.height, 0]),\n            color: chartwerk.axes.color.range.length > 1 ? \n                d3.scaleOrdinal()\n                  .domain(chartwerk.axes.color.domain)\n                  .range(chartwerk.axes.color.range) \n            :   function(d){return chartwerk.axes.color.range[0];},\n        };\n    },\n    \n    baseDomain:  function(werk){\n        var xMax = d3.max(werk.data, function(category) {\n                return d3.max(category.values, function(d){\n                    return d.x; \n                }); \n            }),\n            xMin = d3.min(werk.data, function(category) { \n                return d3.min(category.values, function(d){ \n                    return d.x;\n                });\n            });\n        werk.scales.x.domain([xMin, xMax]);\n    },\n\n    valueDomain: function(werk){\n        var yMax = d3.max(werk.data, function(category) { \n                return d3.max(category.values, function(d){ \n                    return d.y; \n                }); \n            }),\n            yMin = d3.min(werk.data, function(category) {\n                return d3.min(category.values, function(d){ \n                    return d.y; \n                }); \n            });\n        \n        if (chartwerk.axes.value.min && chartwerk.axes.value.max) {\n            werk.scales.y.domain(\n                [chartwerk.axes.value.min, chartwerk.axes.value.max]\n            );\n        } else if (chartwerk.axes.value.min) {\n            werk.scales.y.domain(\n                [chartwerk.axes.value.min, yMax ]\n            );\n        } else if (chartwerk.axes.value.max) {\n            werk.scales.y.domain(\n                [yMin, chartwerk.axes.value.max]\n            );\n        } else {\n            werk.scales.y.domain([yMin, yMax]);\n        }\n        \n        werk.scales.y.nice();\n    },\n\n    axes: function(werk){\n        werk.axes = {\n          x: d3.axisBottom(werk.scales.x)\n              .tickSizeInner(6)\n              .tickSizeOuter(0)\n              .tickPadding(3),\n          y: d3.axisLeft(werk.scales.y)\n              .tickSizeInner(-werk.dims.svg.width)\n              .tickSizeOuter(0)\n              .tickPadding(7)\n              .tickFormat( function(d){ \n                var formatter = werk.scales.y.tickFormat();\n                if (d >= 0) {\n                  return formatter(d) === '0' ? '0' : \n                  chartwerk.axes.value.prefix + formatter(d) + chartwerk.axes.value.suffix;\n                } else {\n                  return \"-\" + chartwerk.axes.value.prefix + formatter(Math.abs(d)) + chartwerk.axes.value.suffix;\n                }\n              }),\n        };\n    },\n\n    baseTicks: function(werk){\n        if (chartwerk.axes.base.type !== 'date') {\n            return;\n        }\n        \n        // Abstract this to a separate file once formats settled.\n        var customLocale = {\n          \"dateTime\": \"%x, %X\",\n          \"date\": \"%-m/%-d/%Y\",\n          \"time\": \"%-I:%M:%S %p\",\n          \"periods\": [\"AM\", \"PM\"],\n          \"days\": [\"Sunday\", \"Monday\", \"Tuesday\", \"Wednesday\", \"Thursday\", \"Friday\", \"Saturday\"],\n          \"shortDays\": [\"S\", \"M\", \"T\", \"W\", \"T\", \"F\", \"S\"],\n          \"months\": [\"January\", \"February\", \"March\", \"April\", \"May\", \"June\", \"July\", \"August\", \"September\", \"October\", \"November\", \"December\"],\n          \"shortMonths\": [\"Jan\", \"Feb\", \"Mar\", \"Apr\", \"May\", \"Jun\", \"Jul\", \"Aug\", \"Sep\", \"Oct\", \"Nov\", \"Dec\"]\n        }\n        \n        d3.timeFormatDefaultLocale(customLocale);\n        \n        \n        var formatMillisecond = d3.timeFormat(\".%L\"),\n            formatSecond = d3.timeFormat(\":%S\"),\n            formatMinute = d3.timeFormat(\"%I:%M\"),\n            formatHour = d3.timeFormat(\"%I %p\"),\n            formatDay = d3.timeFormat(\"%a %d\"),\n            formatWeek = d3.timeFormat(\"%b %d\"),\n            formatMonth = d3.timeFormat(\"%B\"),\n            formatYear = d3.timeFormat(\"%Y\");\n        \n        \n        var s = chartwerk.ui.size;\n        var dateTick;\n        switch(chartwerk.axes.base.format[s].dateString) {\n            case 'Y':\n                dateTick = d3.timeYear;\n                formatYear = d3.timeFormat(\"%Y\");\n                break;\n            case 'y':\n                dateTick = d3.timeYear;\n                formatYear = d3.timeFormat(\"'%y\");\n                break;\n            case 'M':\n                dateTick = d3.timeMonth;\n                formatMonth = d3.timeFormat(\"%B\");\n                formatYear = d3.timeFormat(\"Jan. '%y\");\n                break;\n            case 'm':\n                dateTick = d3.timeMonth;\n                formatMonth = d3.timeFormat(\"%b.\");\n                formatYear = d3.timeFormat(\"J/%y\");\n                break;\n            case 'W':\n            case 'w':\n                dateTick = d3.timeWeek;\n                formatMonth = d3.timeFormat(\"%b.\");\n                formatYear = d3.timeFormat(\"J/%y\");\n                break;\n            case 'D':\n                dateTick = d3.timeDay;\n                formatMonth = d3.timeFormat(\"%b.\");\n                formatYear = d3.timeFormat(\"J/%y\");\n        }\n        \n        function multiFormat(date) {\n          return (d3.timeSecond(date) < date ? formatMillisecond\n              : d3.timeMinute(date) < date ? formatSecond\n              : d3.timeHour(date) < date ? formatMinute\n              : d3.timeDay(date) < date ? formatHour\n              : d3.timeMonth(date) < date ? (d3.timeWeek(date) < date ? formatDay : formatWeek)\n              : d3.timeYear(date) < date ? formatMonth\n              : formatYear)(date);\n        }\n        \n        werk.axes.x.tickFormat(multiFormat)\n        \n        werk.axes.x.ticks(\n            dateTick.every( chartwerk.axes.base.format[s].frequency )\n        );\n    },\n\n    valueTicks: function(werk){\n        var s = chartwerk.ui.size;\n        if (chartwerk.axes.value.format[s].customTicks.length > 0) { \n            werk.axes.y.tickValues(\n                chartwerk.axes.value.format[s].customTicks\n            );\n        } else {\n            werk.axes.y.ticks(\n              chartwerk.axes.value.format[s].ticks\n            );\n        }\n    },\n\n    // Build dims, scales and axes.\n    build: function(werk){\n        this.parse(werk);\n        this.dims(werk);\n        this.scales(werk);\n        this.baseDomain(werk);\n        this.valueDomain(werk);\n        this.axes(werk);\n        this.baseTicks(werk);\n        this.valueTicks(werk);\n        return werk;\n    },\n};",
+        "draw": "function draw(){\n\n    var initialProps = {\n        dims: {\n          single: { width: 260, height: 225 },\n          double: { width: 540, height: 250}\n        },\n    };\n    \n    // Returns object with properties and methods representing\n    // dimensions, scales, axes, etc.\n    var werk = werkHelper.build(initialProps);\n    \n    \n    var line = d3.line()\n        .defined(function(d){ return !isNaN(d.y);})\n        .x(function(d) { return werk.scales.x(d.x); })\n        .y(function(d) { return werk.scales.y(d.y); });\n    \n    var svg = d3.select(\"#chart\")\n        .append(\"svg\")\n        .style(\"background-color\",\"transparent\")\n        .attr(\"width\", werk.dims.svg.width + werk.dims.margins.left + werk.dims.margins.right)\n        .attr(\"height\", werk.dims.svg.height + werk.dims.margins.top + werk.dims.margins.bottom)\n      .append(\"g\")\n        .attr(\"transform\", \"translate(\" + werk.dims.margins.left + \",\" + werk.dims.margins.top + \")\");\n\n    chartwerk.axes.base.shadedRegions.forEach(function(shade) {\n        var rectLeft = werk.scales.x(werk.parsers.base(shade.min));\n        var rectRight = werk.scales.x(werk.parsers.base(shade.max));\n        var minWidth = 2;\n        var width = Math.max(2, rectRight - rectLeft);\n        if (rectRight === rectLeft) {\n            svg.append('line')\n                .attr(\"class\",'solid-line')\n                .attr(\"y1\", 0)\n                .attr(\"y2\", werk.scales.y.range()[0])\n                .attr(\"x1\", rectLeft)\n                .attr(\"x2\", rectLeft);\n        } else {\n            svg.append('rect')\n                .attr(\"class\",\"shaded-area\")\n                .attr('y', 0)\n                .attr('x', rectLeft)\n                .attr('width', width)\n                .attr('height', werk.scales.y.range()[0]); \n        }\n    });\n    \n    chartwerk.axes.value.shadedRegions.forEach(function(shade) {\n        var rectMin = werk.scales.y(werk.parsers.value(shade.min));\n        var rectMax = werk.scales.y(werk.parsers.value(shade.max));\n        var height = Math.max(2, rectMin - rectMax);\n        if (rectMin === rectMax) {\n            svg.append('line')\n                .attr(\"class\",'dotted-line')\n                .attr(\"x1\", 0)\n                .attr(\"x2\", werk.scales.x.range()[1])\n                .attr(\"y1\", rectMin)\n                .attr(\"y2\", rectMin);\n        } else {\n            svg.append('rect')\n                .attr(\"class\",\"shaded-area\")\n                .attr('x', 0)\n                .attr('y', rectMax)\n                .attr('width', werk.scales.x.range()[1])\n                .attr('height', height); \n        }\n    });\n    \n\n    svg.append(\"g\")\n        .attr(\"class\", \"y axis\")\n        .call(werk.axes.y)\n      .append(\"text\")\n        .attr(\"class\",\"label\")\n        .attr(\"y\", -werk.dims.margins.top + 15)\n        .attr(\"x\", -werk.dims.margins.left)\n        .style(\"text-anchor\", \"start\")\n        .text(chartwerk.axes.value.label);\n    \n    svg.append(\"g\")\n        .attr(\"class\", \"x axis\")\n        .attr(\"transform\", \"translate(0,\" + werk.dims.svg.height + \")\")\n        .call(werk.axes.x);\n    \n    \n    var series = svg.selectAll(\".series\")\n        .data(werk.data)\n      .enter().append(\"g\")\n        .attr(\"class\",\"series\");\n    \n    series.append(\"path\")\n    \t\t.attr(\"class\",\"line\")\n    \t\t.attr(\"d\", function(d){ return line(d.values);})\n    \t\t.style(\"stroke\", function(d){ return werk.scales.color(d.name);});\n    \n    //A rect to catch mouse movements\n    var pointerRect = svg.append(\"rect\")\n    \t.attr(\"height\", werk.dims.svg.height)\n    \t.attr(\"width\", werk.dims.svg.width)\n    \t.style(\"fill\",\"none\")\n    \t.style(\"pointer-events\", \"fill\")\n        .on(\"mouseout\",  hideTooltip)\n        .on(\"mousemove\", showTooltip);\n    \n    \n    \n    var tooltip = d3.select(\"#chart\")\n      .append(\"div\")\n        .attr(\"class\",\"tooltip\")\n        .style(\"position\",\"absolute\");\n    tooltip\n      .append(\"div\")\n      .attr(\"class\",\"value\");\n    \n    var trackCirc = svg.append(\"circle\")\n\t\t.attr(\"cx\",0)\n\t\t.attr(\"cy\",0)\n\t\t.attr(\"r\",4)\n\t\t.style(\"fill\",\"none\")\n\t\t.style(\"stroke-width\",2)\n\t\t.style(\"display\",\"none\")\n        .style(\"pointer-events\", \"none\");\n      \n    function hideTooltip(){\n        d3.select(\".tooltip\")\n          .style(\"opacity\", 0);\n        trackCirc\n          .style(\"display\", \"none\");\n    }\n    \n    function showTooltip(){\n        var x0 = werk.scales.x.invert(d3.mouse(this)[0]),\n    \t\ty0 = werk.scales.y.invert(d3.mouse(this)[1]),\n    \n    \t\t//Start dist at a max number so we can check all distances less than\n    \t\tdist = werk.dataDims.xMax - werk.dataDims.xMin + werk.dataDims.yMax - werk.dataDims.yMin,\n    \t\tnearestX = 0,\n    \t\tnearestY = 0,\n    \t\tcolorGroup = \"\",\n    \t\tcomma = d3.format(\",\");\n    \n    \twerk.data.forEach(function(series){\n    \t\tseries.values.forEach(function(d){\n    \t\t\tif(Math.abs(x0 - d.x) + Math.abs(y0 - d.y)  < dist){\n    \t\t\t\tnearestX = d.x\n    \t\t\t\tnearestY = d.y\n    \t\t\t\tcolorGroup = series.name\n    \t\t\t\tdist = Math.abs(x0 - d.x) + Math.abs(y0 - d.y)\n    \t\t\t}\n    \t\t})\n    \n    \t});\n\n\n\t    trackCirc\n\t\t\t.attr(\"cx\", werk.scales.x(nearestX))\n\t\t\t.attr(\"cy\", werk.scales.y(nearestY))\n\t\t\t.style(\"stroke\",\"#333\")\n\t\t\t.style(\"display\",\"\");\n\t\t\n        d3.select(\".tooltip .value\")\n          .style(\"color\", werk.scales.color(colorGroup))\n          .text(function(){\n              var v = chartwerk.axes.value;\n              return v.prefix + comma(nearestY) + v.suffix;\n          });\n        var p = d3.mouse(this.parentElement.parentElement);\n        d3.select(\".tooltip\")\n            .style(\"opacity\", 1)\n            .style(\"top\", function(){\n                var s = chartwerk.ui.size,\n                    h = werk.dims[s].height,\n                    tipH = parseInt(d3.select(\".tooltip\").style(\"height\"), 10),\n                    pos = p[1] > (h / 2) ?\n                        p[1] - 60 : p[1] + 20;\n                return pos.toString() + \"px\";\n            })\n            .style(\"left\", function(){\n                // We position either left or right of the mouse point based\n                // on whether we're past the midpoint of the chart. This protects\n                // against tooltips overflowing embedded iframes.\n                var s = chartwerk.ui.size,\n                    w = werk.dims[s].width,\n                    tipW = parseInt(d3.select(\".tooltip\").style(\"width\"), 10),\n                    pos = p[0] > (w / 2) ?\n                        p[0] - (tipW + 20) : p[0] + 40;\n                return pos.toString() + \"px\";\n            });\n    }\n}",
+        "styles": "#chartwerk {\n    font-family:'Gotham A', 'Gotham B', arial, sans-serif; \n    width:560px;\n}\n#chartwerk.single{\n    width:270px;\n    float:left;\n    overflow:hidden;\n    margin:10px 30px 10px 0;\n}\n#chartwerk #headline { \n    font-weight:bold;\n    font-size:24px;\n}\n#chartwerk #chatter {\n    margin-top:5px;\n}\n#chartwerk #footnote,\n#chartwerk #source,\n#chartwerk #author {\n    font-size:11px;\n    color:grey;\n\n}\n#chartwerk #author {\n    text-align:right;\n}\n#chartwerk #chart{\n    background-color:white;\n}\n#chartwerk #chart-legend \n.chart-legend-container .key-label{\n    font:11px 'Gotham A', 'Gotham B', arial, sans-serif;\n}\n#chartwerk #chart-legend \n.chart-legend-container .key-color{\n    margin-right:2px;\n}\n#chartwerk #chart-legend \n.chart-legend-container .key{\n    margin-right:8px;\n}\n#chartwerk .annotation p{\n    font-family:'Gotham A', 'Gotham B', arial, sans-serif;\n}\n#chartwerk #chart .tooltip{\n    font: 13px 'Gotham A', 'Gotham B', arial, sans-serif;\n    opacity:0;\n    pointer-events:none;\n    background:rgba(255,255,255,.75);\n    padding:5px;\n    width:auto;\n}\n#chartwerk #chart .tooltip .value{\n    font-weight: bold;\n}\n\n#chartwerk #chart path.line{\n    fill: none;\n    stroke-width: 2px;\n}\n\n.axis path,\n.axis line {\n  fill: none;\n  stroke: rgb(180,180,180);\n  shape-rendering: crispEdges;\n}\n.axis text{\n    font-family: 'Gotham A', 'Gotham B', 'Montserrat', arial, sans-serif;\n    fill: rgb(132,132,132);\n    font-size:11px;\n}\n.y.axis line{\n    stroke-dasharray: 3px 3px;\n}\n.y.axis path{\n    display:none;\n}\n.y.axis .label{\n    font-family: 'Gotham A', 'Gotham B', 'Montserrat', arial, sans-serif;\n    font-weight:normal;\n}\nline.dotted-line{\n    stroke:rgb(33,33,33);\n    stroke-width:1px;\n    stroke-dasharray: 7px 5px;\n}\nline.solid-line{\n    stroke:rgb(33,33,33);\n    stroke-width:1px;\n}\nrect.shaded-area{\n    fill:#ddd;\n}",
+        "dependencies": {
+          "styles": ["https://cloud.typography.com/6922714/7642152/css/fonts.css", "https://interactives.dallasnews.com/common/fonts/gotham.css"],
+          "scripts": ["https://cdnjs.cloudflare.com/ajax/libs/d3/4.2.3/d3.min.js"]
+        },
+        "html": "<div id='chart-header'>\n\t<h2 id='headline'></h2>\n\t<div id='chatter'></div> \n</div> \n<div id='chart-ui'>\n\t<!--You can put any necessary buttons, etc., here.-->\n</div>\n<div id='chart-legend'></div>\n<div id='chart'></div> \n<div id='chart-footer'> \n\t<div id='footnote'></div> \n\t<div id='source'></div> \n\t<div id='author'></div> \n</div>"
+      },
+      "datamap": {
+        "value": null,
+        "custom": {},
+        "ignore": [],
+        "scale": null,
+        "series": ["CBM", "GQS"],
+        "sort": [],
+        "facet": null,
+        "annotations": [],
+        "base": "Date"
+      },
+      "axes": {
+        "color": {
+          "ignoreScale": false,
+          "domain": ["CBM", "GQS"],
+          "byFacet": false,
+          "quantizeProps": {
+            "reverseColors": false,
+            "groups": 0,
+            "column": null
+          },
+          "scheme": "categorical.default",
+          "quantize": false,
+          "range": ["#329CEB", "#E34E36"]
+        },
+        "value": {
+          "prefix": "$",
+          "suffix": "",
+          "min": null,
+          "shadedRegions": [],
+          "label": "Dollars",
+          "max": null,
+          "format": {
+            "single": {
+              "customTicks": [],
+              "ticks": 7
+            },
+            "double": {
+              "customTicks": [],
+              "ticks": 7
+            }
+          }
+        },
+        "scale": {
+          "prefix": "",
+          "suffix": ""
+        },
+        "base": {
+          "prefix": "",
+          "type": "date",
+          "suffix": "",
+          "min": null,
+          "shadedRegions": [],
+          "label": "",
+          "max": null,
+          "dateFormat": "%Y-%m-%d",
+          "format": {
+            "single": {
+              "customTicks": [],
+              "dateString": "Y",
+              "ticks": 7,
+              "frequency": 2
+            },
+            "double": {
+              "customTicks": [],
+              "dateString": "Y",
+              "ticks": 7,
+              "frequency": 1
+            }
+          }
+        }
+      },
+      "ui": {
+        "size": "double",
+        "rawData": "Date\tCBM\tGQS\n2015-08-24\t45.47\t32.84\n2015-08-17\t45.14\t32.19\n2015-08-10\t49.05\t34.23\n2015-08-03\t50.32\t34.89\n2015-07-27\t49.25\t36.48\n2015-07-20\t48.91\t35.98\n2015-07-13\t49.04\t37.64\n2015-07-06\t45.61\t37.58\n2015-06-29\t44.24\t38.62\n2015-06-22\t43.99\t38.88\n2015-06-15\t44.77\t38.82\n2015-06-08\t43.39\t38.28\n2015-06-01\t42.69\t38.22\n2015-05-26\t40.02\t38.33\n2015-05-18\t40.91\t38.01\n2015-05-11\t39.00\t38.89\n2015-05-04\t38.71\t39.61\n2015-04-27\t37.28\t40.16\n2015-04-20\t42.97\t40.86\n2015-04-13\t40.98\t40.63\n2015-04-06\t43.21\t41.14\n2015-03-30\t40.61\t42.52\n2015-03-23\t34.93\t42.84\n2015-03-16\t36.69\t43.16\n2015-03-09\t35.98\t41.13\n2015-03-02\t33.77\t40.72\n2015-02-23\t34.25\t41.60\n2015-02-17\t33.56\t41.00\n2015-02-09\t32.96\t41.20\n2015-02-02\t30.01\t41.79\n2015-01-26\t22.43\t41.19\n2015-01-20\t22.77\t42.20\n2015-01-12\t22.36\t40.50\n2015-01-05\t22.13\t42.02\n2014-12-29\t21.58\t42.10\n2014-12-22\t21.79\t41.42\n2014-12-15\t23.00\t41.02\n2014-12-08\t23.66\t39.90\n2014-12-01\t23.51\t40.74\n2014-11-24\t22.75\t39.60\n2014-11-17\t22.74\t38.46\n2014-11-10\t23.17\t39.51\n2014-11-03\t22.66\t38.83\n2014-10-27\t21.08\t37.89\n2014-10-20\t18.07\t36.89\n2014-10-13\t17.40\t35.74\n2014-10-06\t18.47\t36.34\n2014-09-29\t17.19\t42.00\n2014-09-22\t19.05\t42.43\n2014-09-15\t20.81\t43.90\n2014-09-08\t22.46\t44.29\n2014-09-02\t22.35\t44.65\n2014-08-25\t21.92\t46.15\n2014-08-18\t21.46\t45.43\n2014-08-11\t21.50\t41.91\n2014-08-04\t21.77\t42.57\n2014-07-28\t22.60\t40.03\n2014-07-21\t22.08\t39.92\n2014-07-14\t20.51\t39.88\n2014-07-07\t21.70\t40.65\n2014-06-30\t21.82\t42.00\n2014-06-23\t20.41\t41.23\n2014-06-16\t21.00\t41.68\n2014-06-09\t20.35\t41.10\n2014-06-02\t21.58\t42.06\n2014-05-27\t21.49\t41.23\n2014-05-19\t20.90\t41.14\n2014-05-12\t19.48\t41.44\n2014-05-05\t17.99\t40.52\n2014-04-28\t19.23\t39.28\n2014-04-21\t20.67\t38.78\n2014-04-14\t21.04\t38.58\n2014-04-07\t19.67\t38.40\n2014-03-31\t19.97\t41.37\n2014-03-24\t18.18\t40.17\n2014-03-17\t18.94\t41.69\n2014-03-10\t19.43\t42.08\n2014-03-03\t20.90\t42.38\n2014-02-24\t20.07\t43.75\n2014-02-18\t21.77\t42.77\n2014-02-10\t21.19\t42.34\n2014-02-03\t21.05\t42.00\n2014-01-27\t18.77\t38.08\n2014-01-21\t16.51\t37.21\n2014-01-13\t17.55\t37.30\n2014-01-06\t18.64\t39.84\n2013-12-30\t17.20\t39.52\n2013-12-23\t17.62\t38.62\n2013-12-16\t17.93\t38.57\n2013-12-09\t18.39\t38.49\n2013-12-02\t18.90\t39.46\n2013-11-25\t19.50\t40.97\n2013-11-18\t19.34\t41.31\n2013-11-11\t18.84\t42.15\n2013-11-04\t19.14\t41.43\n2013-10-28\t17.26\t36.78\n2013-10-21\t16.81\t36.66\n2013-10-14\t16.54\t37.22\n2013-10-07\t14.76\t36.83\n2013-09-30\t13.44\t40.51\n2013-09-23\t13.09\t40.67\n2013-09-16\t13.20\t41.55\n2013-09-09\t13.16\t41.64\n2013-09-03\t12.76\t40.39\n2013-08-26\t13.63\t40.44\n2013-08-19\t14.10\t41.97\n2013-08-12\t14.33\t43.12\n2013-08-05\t14.21\t44.10\n2013-07-29\t14.40\t46.48\n2013-07-22\t14.87\t45.48\n2013-07-15\t15.33\t45.03\n2013-07-08\t15.28\t45.10\n2013-07-01\t14.40\t43.30\n2013-06-24\t13.97\t41.73\n2013-06-17\t14.33\t41.32\n2013-06-10\t13.92\t41.48\n2013-06-03\t13.57\t42.09\n2013-05-28\t13.76\t40.55\n2013-05-20\t12.63\t40.64\n2013-05-13\t13.16\t40.96\n2013-05-06\t12.87\t40.99\n2013-04-29\t12.30\t38.81\n2013-04-22\t12.62\t37.49\n2013-04-15\t12.56\t37.00\n2013-04-08\t12.81\t38.18\n2013-04-01\t12.05\t36.65\n2013-03-25\t12.79\t35.40\n2013-03-18\t12.52\t35.66\n2013-03-11\t12.20\t36.39\n2013-03-04\t12.32\t36.23\n2013-02-25\t11.87\t33.87\n2013-02-19\t11.92\t31.96\n2013-02-11\t11.89\t32.88\n2013-02-04\t12.53\t32.23\n2013-01-28\t12.08\t32.97\n2013-01-22\t11.53\t33.54\n2013-01-14\t11.27\t32.96\n2013-01-07\t11.77\t31.71\n2012-12-31\t11.54\t32.10\n2012-12-24\t11.30\t30.43\n2012-12-17\t11.35\t31.37\n2012-12-10\t11.38\t31.45\n2012-12-03\t11.06\t31.81\n2012-11-26\t10.97\t34.46\n2012-11-19\t9.64\t35.50\n2012-11-12\t9.34\t33.59\n2012-11-05\t9.66\t33.62\n2012-10-31\t11.65\t35.11\n2012-10-22\t12.16\t35.41\n2012-10-15\t12.95\t36.37\n2012-10-08\t13.06\t36.10\n2012-10-01\t13.04\t37.10\n2012-09-24\t11.73\t35.78\n2012-09-17\t13.01\t36.19\n2012-09-10\t12.64\t35.20\n2012-09-04\t12.46\t35.93\n2012-08-27\t12.18\t35.82\n2012-08-20\t12.40\t35.12\n2012-08-13\t12.49\t35.99\n2012-08-06\t10.93\t34.21\n2012-07-30\t10.95\t33.46\n2012-07-23\t9.67\t29.91\n2012-07-16\t9.49\t29.20\n2012-07-09\t9.50\t27.90\n2012-07-02\t10.07\t27.88\n2012-06-25\t9.41\t27.36\n2012-06-18\t8.30\t27.36\n2012-06-11\t7.54\t26.73\n2012-06-04\t7.20\t26.24\n2012-05-29\t7.08\t25.26\n2012-05-21\t7.08\t27.16\n2012-05-14\t6.78\t25.71\n2012-05-07\t6.86\t28.00\n2012-04-30\t6.87\t28.20\n2012-04-23\t6.72\t28.53\n2012-04-16\t6.37\t27.85\n2012-04-09\t6.21\t26.56\n2012-04-02\t6.75\t26.45\n2012-03-26\t6.99\t26.14\n2012-03-19\t6.69\t26.46\n2012-03-12\t6.70\t25.39\n2012-03-05\t6.88\t25.00\n2012-02-27\t6.55\t24.41\n2012-02-21\t7.52\t22.57\n2012-02-13\t7.55\t22.72\n2012-02-06\t7.08\t21.59\n2012-01-30\t8.24\t21.71\n2012-01-23\t7.97\t18.93\n2012-01-17\t7.58\t18.63\n2012-01-09\t7.52\t18.26\n2012-01-03\t7.90\t18.00\n2011-12-27\t7.18\t18.55\n2011-12-19\t7.40\t18.61\n2011-12-12\t7.61\t18.30\n2011-12-05\t7.38\t18.85\n2011-11-28\t7.10\t18.70\n2011-11-21\t6.21\t17.62\n2011-11-14\t6.29\t18.76\n2011-11-07\t6.00\t20.33\n2011-10-31\t5.63\t19.65\n2011-10-24\t5.66\t19.33\n2011-10-17\t5.46\t18.71\n2011-10-10\t5.52\t17.78\n2011-10-03\t4.90\t17.30\n2011-09-26\t5.04\t16.24\n2011-09-19\t4.80\t16.31\n2011-09-12\t5.35\t17.04\n2011-09-06\t4.86\t16.00\n2011-08-29\t4.70\t15.60\n2011-08-22\t4.54\t16.28\n2011-08-15\t4.31\t15.69\n2011-08-08\t4.81\t16.49\n2011-08-01\t4.80\t16.75\n2011-07-25\t4.41\t19.29\n2011-07-18\t4.94\t19.66\n2011-07-11\t5.09\t18.91\n2011-07-05\t4.93\t18.98\n2011-06-27\t4.76\t18.28\n2011-06-20\t4.29\t17.66\n2011-06-13\t4.07\t17.83\n2011-06-06\t4.24\t17.72\n2011-05-31\t4.47\t17.92\n2011-05-23\t4.82\t19.20\n2011-05-16\t4.78\t19.22\n2011-05-09\t5.04\t23.05\n2011-05-02\t4.60\t22.60\n2011-04-25\t5.26\t23.24\n2011-04-18\t5.01\t21.99\n2011-04-11\t5.04\t22.47\n2011-04-04\t5.05\t22.25\n2011-03-28\t5.50\t22.63\n2011-03-21\t5.36\t22.56\n2011-03-14\t4.61\t21.87\n2011-03-07\t5.05\t21.97\n2011-02-28\t5.43\t21.59\n2011-02-22\t5.54\t22.75\n2011-02-14\t5.61\t23.05\n2011-02-07\t5.95\t21.40\n2011-01-31\t4.94\t20.10\n2011-01-24\t4.71\t19.20\n2011-01-18\t4.88\t20.10\n2011-01-10\t5.23\t20.41\n2011-01-03\t5.01\t20.51\n2010-12-27\t5.17\t22.14\n2010-12-20\t5.92\t21.46\n2010-12-13\t5.85\t21.19\n2010-12-06\t4.98\t21.48\n2010-11-29\t4.33\t21.44\n2010-11-22\t4.20\t20.90\n2010-11-15\t4.31\t20.70\n2010-11-08\t4.25\t20.49\n2010-11-01\t4.27\t20.81\n2010-10-25\t4.53\t19.01\n2010-10-18\t4.44\t19.15\n2010-10-11\t4.74\t19.52\n2010-10-04\t4.17\t18.21\n2010-09-27\t4.10\t18.51\n2010-09-20\t4.41\t18.83\n2010-09-13\t4.01\t18.91\n2010-09-07\t4.12\t17.37\n2010-08-30\t4.30\t17.65\n2010-08-23\t4.06\t17.03\n2010-08-16\t4.36\t17.32\n2010-08-09\t3.80\t17.67\n2010-08-02\t3.97\t18.28\n2010-07-26\t3.55\t18.11\n2010-07-19\t3.50\t18.41\n2010-07-12\t3.11\t18.13\n2010-07-06\t3.11\t18.53\n2010-06-28\t2.98\t19.48\n2010-06-21\t3.40\t20.20\n2010-06-14\t3.75\t21.24\n2010-06-07\t3.71\t21.99\n2010-06-01\t3.78\t20.96\n2010-05-24\t4.17\t21.80\n2010-05-17\t4.36\t22.15\n2010-05-10\t4.46\t22.96\n2010-05-03\t4.25\t22.27\n2010-04-26\t4.39\t24.73\n2010-04-19\t4.30\t26.06\n2010-04-12\t4.42\t25.00\n2010-04-05\t4.37\t24.85\n2010-03-29\t4.11\t23.63\n2010-03-22\t3.88\t23.42\n2010-03-15\t4.25\t23.22\n2010-03-08\t4.23\t22.80\n2010-03-01\t4.24\t22.32\n2010-02-22\t3.77\t21.50\n2010-02-16\t4.11\t19.85\n2010-02-08\t4.31\t19.95\n2010-02-01\t5.19\t19.88\n2010-01-25\t5.38\t19.08\n2010-01-19\t5.74\t18.86\n2010-01-11\t5.83\t19.56\n2010-01-04\t5.68\t20.40\n2009-12-28\t5.58\t20.95\n2009-12-21\t5.69\t20.71\n2009-12-14\t5.43\t20.89\n2009-12-07\t5.35\t21.46\n2009-11-30\t5.48\t21.77\n2009-11-23\t5.70\t22.03\n2009-11-16\t5.86\t21.95\n2009-11-09\t6.15\t22.42\n2009-11-02\t6.27\t23.03\n2009-10-26\t6.00\t21.34\n2009-10-19\t6.78\t22.02\n2009-10-12\t6.95\t22.96\n2009-10-05\t6.77\t22.24\n2009-09-28\t6.12\t20.81\n2009-09-21\t6.15\t21.48\n2009-09-14\t6.43\t22.02\n2009-09-08\t6.06\t21.60\n2009-08-31\t5.72\t21.12\n2009-08-24\t5.52\t19.93\n2009-08-17\t5.36\t19.48\n2009-08-10\t4.66\t18.78\n2009-08-03\t4.58\t18.58\n2009-07-27\t4.58\t16.32\n2009-07-20\t4.46\t15.94\n2009-07-13\t4.40\t16.17\n2009-07-06\t4.10\t14.96\n2009-06-29\t4.05\t15.39\n2009-06-22\t4.48\t16.06\n2009-06-15\t4.20\t15.80\n2009-06-08\t4.00\t16.37\n2009-06-01\t4.10\t16.63\n2009-05-26\t3.60\t17.85\n2009-05-18\t3.91\t16.39\n2009-05-11\t3.71\t15.16\n2009-05-04\t4.00\t16.55\n2009-04-27\t2.45\t15.77\n2009-04-20\t2.58\t15.28\n2009-04-13\t2.78\t15.12\n2009-04-06\t2.84\t15.09\n2009-03-30\t2.30\t15.25\n2009-03-23\t2.48\t13.06\n2009-03-16\t2.49\t11.98\n2009-03-09\t1.75\t11.99\n2009-03-02\t1.50\t9.85\n2009-02-23\t2.16\t10.79\n2009-02-17\t3.30\t11.55\n2009-02-09\t3.98\t11.62\n2009-02-02\t4.62\t11.94\n2009-01-26\t3.27\t11.28\n2009-01-20\t3.50\t12.00\n2009-01-12\t4.30\t12.14\n2009-01-05\t4.45\t12.99\n2008-12-29\t4.35\t14.07\n2008-12-22\t4.52\t12.97\n2008-12-15\t4.63\t13.57\n2008-12-08\t3.86\t13.19\n2008-12-01\t3.69\t14.01\n2008-11-24\t3.48\t13.02\n2008-11-17\t2.50\t12.10\n2008-11-10\t2.94\t11.55\n2008-11-03\t3.88\t12.82\n2008-10-27\t4.50\t12.94\n2008-10-20\t4.59\t11.21\n2008-10-13\t4.98\t13.42\n2008-10-06\t4.36\t13.82\n2008-09-29\t4.59\t16.83\n2008-09-22\t6.38\t18.37\n2008-09-15\t6.60\t19.08\n2008-09-08\t6.48\t19.37\n2008-09-02\t6.24\t19.19\n2008-08-25\t6.51\t19.45\n2008-08-18\t6.73\t19.88\n2008-08-11\t6.74\t19.40\n2008-08-04\t6.60\t18.09\n2008-07-28\t7.69\t16.34\n2008-07-21\t7.89\t16.29\n2008-07-14\t6.83\t16.60\n2008-07-07\t6.03\t15.25\n2008-06-30\t5.45\t16.45\n2008-06-23\t5.98\t16.74\n2008-06-16\t6.48\t17.45\n2008-06-09\t6.32\t18.00\n2008-06-02\t6.35\t17.17\n2008-05-27\t6.15\t18.25\n2008-05-19\t5.59\t17.94\n2008-05-12\t5.99\t18.43\n2008-05-05\t5.51\t17.94\n2008-04-28\t5.96\t18.68\n2008-04-21\t5.97\t19.34\n2008-04-14\t5.95\t19.00\n2008-04-07\t6.20\t17.95\n2008-03-31\t7.09\t19.05\n2008-03-24\t6.94\t19.52\n2008-03-17\t8.01\t21.37\n2008-03-10\t7.83\t19.81\n2008-03-03\t7.94\t19.58\n2008-02-25\t8.73\t20.17\n2008-02-19\t9.48\t19.71\n2008-02-11\t9.84\t19.70\n2008-02-04\t10.46\t19.78\n2008-01-28\t9.73\t19.34\n2008-01-22\t9.32\t17.80\n2008-01-14\t9.76\t17.23\n2008-01-07\t8.57\t17.20\n2007-12-31\t7.80\t19.66\n2007-12-24\t8.36\t21.36\n2007-12-17\t9.03\t21.76\n2007-12-10\t8.50\t21.18\n2007-12-03\t8.24\t21.57\n2007-11-26\t7.74\t20.40\n2007-11-19\t7.71\t18.89\n2007-11-12\t7.97\t20.09\n2007-11-05\t9.17\t19.38\n2007-10-29\t10.52\t18.21\n2007-10-22\t11.37\t18.61\n2007-10-15\t10.67\t17.75\n2007-10-08\t11.45\t19.01\n2007-10-01\t10.88\t18.91\n2007-09-24\t10.89\t18.44\n2007-09-17\t12.06\t18.55\n2007-09-10\t11.33\t18.00\n2007-09-04\t11.42\t17.94\n2007-08-27\t12.47\t18.76\n2007-08-20\t12.83\t18.51\n2007-08-13\t13.38\t17.27\n2007-08-06\t11.81\t16.75\n2007-07-30\t12.96\t16.44\n2007-07-23\t13.30\t17.79\n2007-07-16\t13.69\t18.63\n2007-07-09\t14.35\t18.56\n2007-07-02\t13.58\t19.22\n2007-06-25\t13.27\t19.10\n2007-06-18\t13.45\t19.34\n2007-06-11\t13.40\t18.97\n2007-06-04\t12.69\t18.47\n2007-05-29\t12.53\t18.51\n2007-05-21\t12.53\t18.18\n2007-05-14\t12.53\t18.44\n2007-05-07\t12.13\t18.32\n2007-04-30\t11.67\t18.50\n2007-04-23\t24.56\t18.31\n2007-04-16\t25.04\t18.96\n2007-04-09\t25.45\t18.47\n2007-04-02\t24.97\t17.64\n2007-03-26\t24.60\t17.21\n2007-03-19\t24.84\t17.85\n2007-03-12\t24.50\t17.50\n2007-03-05\t23.13\t17.84\n2007-02-26\t22.67\t18.40\n2007-02-20\t23.49\t19.81\n2007-02-12\t23.50\t20.02\n2007-02-05\t23.38\t19.55\n2007-01-29\t21.92\t19.47\n2007-01-22\t21.46\t19.04\n2007-01-16\t22.05\t20.00\n2007-01-08\t22.33\t20.30\n2007-01-03\t22.37\t18.89\n2006-12-26\t22.72\t19.50\n2006-12-18\t22.88\t19.95\n2006-12-11\t22.39\t20.39\n2006-12-04\t22.60\t19.66\n2006-11-27\t22.12\t18.68\n2006-11-20\t22.31\t19.30\n2006-11-13\t22.39\t19.81\n2006-11-06\t22.66\t20.19\n2006-10-30\t22.67\t19.57\n2006-10-23\t23.88\t20.72\n2006-10-16\t21.53\t19.30\n2006-10-09\t21.59\t19.85\n2006-10-02\t21.37\t19.07\n2006-09-25\t20.71\t18.95\n2006-09-18\t21.05\t18.39\n2006-09-11\t21.70\t17.92\n2006-09-05\t21.18\t16.90\n2006-08-28\t22.76\t16.90\n2006-08-21\t21.52\t16.61\n2006-08-14\t21.13\t16.65\n2006-08-07\t19.78\t16.90\n2006-07-31\t20.94\t16.75\n2006-07-24\t21.59\t17.12\n",
+        "datamap": [{
+          "available": true,
+          "class": "base",
+          "alias": "X axis"
+        }, {
+          "available": false,
+          "class": "value",
+          "alias": "value axis"
+        }, {
+          "available": false,
+          "class": "scale",
+          "alias": "scale axis"
+        }, {
+          "available": true,
+          "class": "series",
+          "alias": "Y axis"
+        }, {
+          "available": false,
+          "class": "facet",
+          "alias": "faceting column"
+        }, {
+          "available": false,
+          "class": "ignore",
+          "alias": "ignored column"
+        }]
+      },
+      "margins": {
+        "single": {
+          "left": 0.11,
+          "top": 0.05,
+          "right": 0.020000000000000018,
+          "bottom": 0.10999999999999999
+        },
+        "double": {
+          "left": 0.06,
+          "top": 0.05,
+          "right": 0.020000000000000018,
+          "bottom": 0.07999999999999996
+        }
+      },
+      "data": [{
+        "GQS": 32.84,
+        "Date": "2015-08-24",
+        "CBM": 45.47
+      }, {
+        "GQS": 32.19,
+        "Date": "2015-08-17",
+        "CBM": 45.14
+      }, {
+        "GQS": 34.23,
+        "Date": "2015-08-10",
+        "CBM": 49.05
+      }, {
+        "GQS": 34.89,
+        "Date": "2015-08-03",
+        "CBM": 50.32
+      }, {
+        "GQS": 36.48,
+        "Date": "2015-07-27",
+        "CBM": 49.25
+      }, {
+        "GQS": 35.98,
+        "Date": "2015-07-20",
+        "CBM": 48.91
+      }, {
+        "GQS": 37.64,
+        "Date": "2015-07-13",
+        "CBM": 49.04
+      }, {
+        "GQS": 37.58,
+        "Date": "2015-07-06",
+        "CBM": 45.61
+      }, {
+        "GQS": 38.62,
+        "Date": "2015-06-29",
+        "CBM": 44.24
+      }, {
+        "GQS": 38.88,
+        "Date": "2015-06-22",
+        "CBM": 43.99
+      }, {
+        "GQS": 38.82,
+        "Date": "2015-06-15",
+        "CBM": 44.77
+      }, {
+        "GQS": 38.28,
+        "Date": "2015-06-08",
+        "CBM": 43.39
+      }, {
+        "GQS": 38.22,
+        "Date": "2015-06-01",
+        "CBM": 42.69
+      }, {
+        "GQS": 38.33,
+        "Date": "2015-05-26",
+        "CBM": 40.02
+      }, {
+        "GQS": 38.01,
+        "Date": "2015-05-18",
+        "CBM": 40.91
+      }, {
+        "GQS": 38.89,
+        "Date": "2015-05-11",
+        "CBM": 39
+      }, {
+        "GQS": 39.61,
+        "Date": "2015-05-04",
+        "CBM": 38.71
+      }, {
+        "GQS": 40.16,
+        "Date": "2015-04-27",
+        "CBM": 37.28
+      }, {
+        "GQS": 40.86,
+        "Date": "2015-04-20",
+        "CBM": 42.97
+      }, {
+        "GQS": 40.63,
+        "Date": "2015-04-13",
+        "CBM": 40.98
+      }, {
+        "GQS": 41.14,
+        "Date": "2015-04-06",
+        "CBM": 43.21
+      }, {
+        "GQS": 42.52,
+        "Date": "2015-03-30",
+        "CBM": 40.61
+      }, {
+        "GQS": 42.84,
+        "Date": "2015-03-23",
+        "CBM": 34.93
+      }, {
+        "GQS": 43.16,
+        "Date": "2015-03-16",
+        "CBM": 36.69
+      }, {
+        "GQS": 41.13,
+        "Date": "2015-03-09",
+        "CBM": 35.98
+      }, {
+        "GQS": 40.72,
+        "Date": "2015-03-02",
+        "CBM": 33.77
+      }, {
+        "GQS": 41.6,
+        "Date": "2015-02-23",
+        "CBM": 34.25
+      }, {
+        "GQS": 41,
+        "Date": "2015-02-17",
+        "CBM": 33.56
+      }, {
+        "GQS": 41.2,
+        "Date": "2015-02-09",
+        "CBM": 32.96
+      }, {
+        "GQS": 41.79,
+        "Date": "2015-02-02",
+        "CBM": 30.01
+      }, {
+        "GQS": 41.19,
+        "Date": "2015-01-26",
+        "CBM": 22.43
+      }, {
+        "GQS": 42.2,
+        "Date": "2015-01-20",
+        "CBM": 22.77
+      }, {
+        "GQS": 40.5,
+        "Date": "2015-01-12",
+        "CBM": 22.36
+      }, {
+        "GQS": 42.02,
+        "Date": "2015-01-05",
+        "CBM": 22.13
+      }, {
+        "GQS": 42.1,
+        "Date": "2014-12-29",
+        "CBM": 21.58
+      }, {
+        "GQS": 41.42,
+        "Date": "2014-12-22",
+        "CBM": 21.79
+      }, {
+        "GQS": 41.02,
+        "Date": "2014-12-15",
+        "CBM": 23
+      }, {
+        "GQS": 39.9,
+        "Date": "2014-12-08",
+        "CBM": 23.66
+      }, {
+        "GQS": 40.74,
+        "Date": "2014-12-01",
+        "CBM": 23.51
+      }, {
+        "GQS": 39.6,
+        "Date": "2014-11-24",
+        "CBM": 22.75
+      }, {
+        "GQS": 38.46,
+        "Date": "2014-11-17",
+        "CBM": 22.74
+      }, {
+        "GQS": 39.51,
+        "Date": "2014-11-10",
+        "CBM": 23.17
+      }, {
+        "GQS": 38.83,
+        "Date": "2014-11-03",
+        "CBM": 22.66
+      }, {
+        "GQS": 37.89,
+        "Date": "2014-10-27",
+        "CBM": 21.08
+      }, {
+        "GQS": 36.89,
+        "Date": "2014-10-20",
+        "CBM": 18.07
+      }, {
+        "GQS": 35.74,
+        "Date": "2014-10-13",
+        "CBM": 17.4
+      }, {
+        "GQS": 36.34,
+        "Date": "2014-10-06",
+        "CBM": 18.47
+      }, {
+        "GQS": 42,
+        "Date": "2014-09-29",
+        "CBM": 17.19
+      }, {
+        "GQS": 42.43,
+        "Date": "2014-09-22",
+        "CBM": 19.05
+      }, {
+        "GQS": 43.9,
+        "Date": "2014-09-15",
+        "CBM": 20.81
+      }, {
+        "GQS": 44.29,
+        "Date": "2014-09-08",
+        "CBM": 22.46
+      }, {
+        "GQS": 44.65,
+        "Date": "2014-09-02",
+        "CBM": 22.35
+      }, {
+        "GQS": 46.15,
+        "Date": "2014-08-25",
+        "CBM": 21.92
+      }, {
+        "GQS": 45.43,
+        "Date": "2014-08-18",
+        "CBM": 21.46
+      }, {
+        "GQS": 41.91,
+        "Date": "2014-08-11",
+        "CBM": 21.5
+      }, {
+        "GQS": 42.57,
+        "Date": "2014-08-04",
+        "CBM": 21.77
+      }, {
+        "GQS": 40.03,
+        "Date": "2014-07-28",
+        "CBM": 22.6
+      }, {
+        "GQS": 39.92,
+        "Date": "2014-07-21",
+        "CBM": 22.08
+      }, {
+        "GQS": 39.88,
+        "Date": "2014-07-14",
+        "CBM": 20.51
+      }, {
+        "GQS": 40.65,
+        "Date": "2014-07-07",
+        "CBM": 21.7
+      }, {
+        "GQS": 42,
+        "Date": "2014-06-30",
+        "CBM": 21.82
+      }, {
+        "GQS": 41.23,
+        "Date": "2014-06-23",
+        "CBM": 20.41
+      }, {
+        "GQS": 41.68,
+        "Date": "2014-06-16",
+        "CBM": 21
+      }, {
+        "GQS": 41.1,
+        "Date": "2014-06-09",
+        "CBM": 20.35
+      }, {
+        "GQS": 42.06,
+        "Date": "2014-06-02",
+        "CBM": 21.58
+      }, {
+        "GQS": 41.23,
+        "Date": "2014-05-27",
+        "CBM": 21.49
+      }, {
+        "GQS": 41.14,
+        "Date": "2014-05-19",
+        "CBM": 20.9
+      }, {
+        "GQS": 41.44,
+        "Date": "2014-05-12",
+        "CBM": 19.48
+      }, {
+        "GQS": 40.52,
+        "Date": "2014-05-05",
+        "CBM": 17.99
+      }, {
+        "GQS": 39.28,
+        "Date": "2014-04-28",
+        "CBM": 19.23
+      }, {
+        "GQS": 38.78,
+        "Date": "2014-04-21",
+        "CBM": 20.67
+      }, {
+        "GQS": 38.58,
+        "Date": "2014-04-14",
+        "CBM": 21.04
+      }, {
+        "GQS": 38.4,
+        "Date": "2014-04-07",
+        "CBM": 19.67
+      }, {
+        "GQS": 41.37,
+        "Date": "2014-03-31",
+        "CBM": 19.97
+      }, {
+        "GQS": 40.17,
+        "Date": "2014-03-24",
+        "CBM": 18.18
+      }, {
+        "GQS": 41.69,
+        "Date": "2014-03-17",
+        "CBM": 18.94
+      }, {
+        "GQS": 42.08,
+        "Date": "2014-03-10",
+        "CBM": 19.43
+      }, {
+        "GQS": 42.38,
+        "Date": "2014-03-03",
+        "CBM": 20.9
+      }, {
+        "GQS": 43.75,
+        "Date": "2014-02-24",
+        "CBM": 20.07
+      }, {
+        "GQS": 42.77,
+        "Date": "2014-02-18",
+        "CBM": 21.77
+      }, {
+        "GQS": 42.34,
+        "Date": "2014-02-10",
+        "CBM": 21.19
+      }, {
+        "GQS": 42,
+        "Date": "2014-02-03",
+        "CBM": 21.05
+      }, {
+        "GQS": 38.08,
+        "Date": "2014-01-27",
+        "CBM": 18.77
+      }, {
+        "GQS": 37.21,
+        "Date": "2014-01-21",
+        "CBM": 16.51
+      }, {
+        "GQS": 37.3,
+        "Date": "2014-01-13",
+        "CBM": 17.55
+      }, {
+        "GQS": 39.84,
+        "Date": "2014-01-06",
+        "CBM": 18.64
+      }, {
+        "GQS": 39.52,
+        "Date": "2013-12-30",
+        "CBM": 17.2
+      }, {
+        "GQS": 38.62,
+        "Date": "2013-12-23",
+        "CBM": 17.62
+      }, {
+        "GQS": 38.57,
+        "Date": "2013-12-16",
+        "CBM": 17.93
+      }, {
+        "GQS": 38.49,
+        "Date": "2013-12-09",
+        "CBM": 18.39
+      }, {
+        "GQS": 39.46,
+        "Date": "2013-12-02",
+        "CBM": 18.9
+      }, {
+        "GQS": 40.97,
+        "Date": "2013-11-25",
+        "CBM": 19.5
+      }, {
+        "GQS": 41.31,
+        "Date": "2013-11-18",
+        "CBM": 19.34
+      }, {
+        "GQS": 42.15,
+        "Date": "2013-11-11",
+        "CBM": 18.84
+      }, {
+        "GQS": 41.43,
+        "Date": "2013-11-04",
+        "CBM": 19.14
+      }, {
+        "GQS": 36.78,
+        "Date": "2013-10-28",
+        "CBM": 17.26
+      }, {
+        "GQS": 36.66,
+        "Date": "2013-10-21",
+        "CBM": 16.81
+      }, {
+        "GQS": 37.22,
+        "Date": "2013-10-14",
+        "CBM": 16.54
+      }, {
+        "GQS": 36.83,
+        "Date": "2013-10-07",
+        "CBM": 14.76
+      }, {
+        "GQS": 40.51,
+        "Date": "2013-09-30",
+        "CBM": 13.44
+      }, {
+        "GQS": 40.67,
+        "Date": "2013-09-23",
+        "CBM": 13.09
+      }, {
+        "GQS": 41.55,
+        "Date": "2013-09-16",
+        "CBM": 13.2
+      }, {
+        "GQS": 41.64,
+        "Date": "2013-09-09",
+        "CBM": 13.16
+      }, {
+        "GQS": 40.39,
+        "Date": "2013-09-03",
+        "CBM": 12.76
+      }, {
+        "GQS": 40.44,
+        "Date": "2013-08-26",
+        "CBM": 13.63
+      }, {
+        "GQS": 41.97,
+        "Date": "2013-08-19",
+        "CBM": 14.1
+      }, {
+        "GQS": 43.12,
+        "Date": "2013-08-12",
+        "CBM": 14.33
+      }, {
+        "GQS": 44.1,
+        "Date": "2013-08-05",
+        "CBM": 14.21
+      }, {
+        "GQS": 46.48,
+        "Date": "2013-07-29",
+        "CBM": 14.4
+      }, {
+        "GQS": 45.48,
+        "Date": "2013-07-22",
+        "CBM": 14.87
+      }, {
+        "GQS": 45.03,
+        "Date": "2013-07-15",
+        "CBM": 15.33
+      }, {
+        "GQS": 45.1,
+        "Date": "2013-07-08",
+        "CBM": 15.28
+      }, {
+        "GQS": 43.3,
+        "Date": "2013-07-01",
+        "CBM": 14.4
+      }, {
+        "GQS": 41.73,
+        "Date": "2013-06-24",
+        "CBM": 13.97
+      }, {
+        "GQS": 41.32,
+        "Date": "2013-06-17",
+        "CBM": 14.33
+      }, {
+        "GQS": 41.48,
+        "Date": "2013-06-10",
+        "CBM": 13.92
+      }, {
+        "GQS": 42.09,
+        "Date": "2013-06-03",
+        "CBM": 13.57
+      }, {
+        "GQS": 40.55,
+        "Date": "2013-05-28",
+        "CBM": 13.76
+      }, {
+        "GQS": 40.64,
+        "Date": "2013-05-20",
+        "CBM": 12.63
+      }, {
+        "GQS": 40.96,
+        "Date": "2013-05-13",
+        "CBM": 13.16
+      }, {
+        "GQS": 40.99,
+        "Date": "2013-05-06",
+        "CBM": 12.87
+      }, {
+        "GQS": 38.81,
+        "Date": "2013-04-29",
+        "CBM": 12.3
+      }, {
+        "GQS": 37.49,
+        "Date": "2013-04-22",
+        "CBM": 12.62
+      }, {
+        "GQS": 37,
+        "Date": "2013-04-15",
+        "CBM": 12.56
+      }, {
+        "GQS": 38.18,
+        "Date": "2013-04-08",
+        "CBM": 12.81
+      }, {
+        "GQS": 36.65,
+        "Date": "2013-04-01",
+        "CBM": 12.05
+      }, {
+        "GQS": 35.4,
+        "Date": "2013-03-25",
+        "CBM": 12.79
+      }, {
+        "GQS": 35.66,
+        "Date": "2013-03-18",
+        "CBM": 12.52
+      }, {
+        "GQS": 36.39,
+        "Date": "2013-03-11",
+        "CBM": 12.2
+      }, {
+        "GQS": 36.23,
+        "Date": "2013-03-04",
+        "CBM": 12.32
+      }, {
+        "GQS": 33.87,
+        "Date": "2013-02-25",
+        "CBM": 11.87
+      }, {
+        "GQS": 31.96,
+        "Date": "2013-02-19",
+        "CBM": 11.92
+      }, {
+        "GQS": 32.88,
+        "Date": "2013-02-11",
+        "CBM": 11.89
+      }, {
+        "GQS": 32.23,
+        "Date": "2013-02-04",
+        "CBM": 12.53
+      }, {
+        "GQS": 32.97,
+        "Date": "2013-01-28",
+        "CBM": 12.08
+      }, {
+        "GQS": 33.54,
+        "Date": "2013-01-22",
+        "CBM": 11.53
+      }, {
+        "GQS": 32.96,
+        "Date": "2013-01-14",
+        "CBM": 11.27
+      }, {
+        "GQS": 31.71,
+        "Date": "2013-01-07",
+        "CBM": 11.77
+      }, {
+        "GQS": 32.1,
+        "Date": "2012-12-31",
+        "CBM": 11.54
+      }, {
+        "GQS": 30.43,
+        "Date": "2012-12-24",
+        "CBM": 11.3
+      }, {
+        "GQS": 31.37,
+        "Date": "2012-12-17",
+        "CBM": 11.35
+      }, {
+        "GQS": 31.45,
+        "Date": "2012-12-10",
+        "CBM": 11.38
+      }, {
+        "GQS": 31.81,
+        "Date": "2012-12-03",
+        "CBM": 11.06
+      }, {
+        "GQS": 34.46,
+        "Date": "2012-11-26",
+        "CBM": 10.97
+      }, {
+        "GQS": 35.5,
+        "Date": "2012-11-19",
+        "CBM": 9.64
+      }, {
+        "GQS": 33.59,
+        "Date": "2012-11-12",
+        "CBM": 9.34
+      }, {
+        "GQS": 33.62,
+        "Date": "2012-11-05",
+        "CBM": 9.66
+      }, {
+        "GQS": 35.11,
+        "Date": "2012-10-31",
+        "CBM": 11.65
+      }, {
+        "GQS": 35.41,
+        "Date": "2012-10-22",
+        "CBM": 12.16
+      }, {
+        "GQS": 36.37,
+        "Date": "2012-10-15",
+        "CBM": 12.95
+      }, {
+        "GQS": 36.1,
+        "Date": "2012-10-08",
+        "CBM": 13.06
+      }, {
+        "GQS": 37.1,
+        "Date": "2012-10-01",
+        "CBM": 13.04
+      }, {
+        "GQS": 35.78,
+        "Date": "2012-09-24",
+        "CBM": 11.73
+      }, {
+        "GQS": 36.19,
+        "Date": "2012-09-17",
+        "CBM": 13.01
+      }, {
+        "GQS": 35.2,
+        "Date": "2012-09-10",
+        "CBM": 12.64
+      }, {
+        "GQS": 35.93,
+        "Date": "2012-09-04",
+        "CBM": 12.46
+      }, {
+        "GQS": 35.82,
+        "Date": "2012-08-27",
+        "CBM": 12.18
+      }, {
+        "GQS": 35.12,
+        "Date": "2012-08-20",
+        "CBM": 12.4
+      }, {
+        "GQS": 35.99,
+        "Date": "2012-08-13",
+        "CBM": 12.49
+      }, {
+        "GQS": 34.21,
+        "Date": "2012-08-06",
+        "CBM": 10.93
+      }, {
+        "GQS": 33.46,
+        "Date": "2012-07-30",
+        "CBM": 10.95
+      }, {
+        "GQS": 29.91,
+        "Date": "2012-07-23",
+        "CBM": 9.67
+      }, {
+        "GQS": 29.2,
+        "Date": "2012-07-16",
+        "CBM": 9.49
+      }, {
+        "GQS": 27.9,
+        "Date": "2012-07-09",
+        "CBM": 9.5
+      }, {
+        "GQS": 27.88,
+        "Date": "2012-07-02",
+        "CBM": 10.07
+      }, {
+        "GQS": 27.36,
+        "Date": "2012-06-25",
+        "CBM": 9.41
+      }, {
+        "GQS": 27.36,
+        "Date": "2012-06-18",
+        "CBM": 8.3
+      }, {
+        "GQS": 26.73,
+        "Date": "2012-06-11",
+        "CBM": 7.54
+      }, {
+        "GQS": 26.24,
+        "Date": "2012-06-04",
+        "CBM": 7.2
+      }, {
+        "GQS": 25.26,
+        "Date": "2012-05-29",
+        "CBM": 7.08
+      }, {
+        "GQS": 27.16,
+        "Date": "2012-05-21",
+        "CBM": 7.08
+      }, {
+        "GQS": 25.71,
+        "Date": "2012-05-14",
+        "CBM": 6.78
+      }, {
+        "GQS": 28,
+        "Date": "2012-05-07",
+        "CBM": 6.86
+      }, {
+        "GQS": 28.2,
+        "Date": "2012-04-30",
+        "CBM": 6.87
+      }, {
+        "GQS": 28.53,
+        "Date": "2012-04-23",
+        "CBM": 6.72
+      }, {
+        "GQS": 27.85,
+        "Date": "2012-04-16",
+        "CBM": 6.37
+      }, {
+        "GQS": 26.56,
+        "Date": "2012-04-09",
+        "CBM": 6.21
+      }, {
+        "GQS": 26.45,
+        "Date": "2012-04-02",
+        "CBM": 6.75
+      }, {
+        "GQS": 26.14,
+        "Date": "2012-03-26",
+        "CBM": 6.99
+      }, {
+        "GQS": 26.46,
+        "Date": "2012-03-19",
+        "CBM": 6.69
+      }, {
+        "GQS": 25.39,
+        "Date": "2012-03-12",
+        "CBM": 6.7
+      }, {
+        "GQS": 25,
+        "Date": "2012-03-05",
+        "CBM": 6.88
+      }, {
+        "GQS": 24.41,
+        "Date": "2012-02-27",
+        "CBM": 6.55
+      }, {
+        "GQS": 22.57,
+        "Date": "2012-02-21",
+        "CBM": 7.52
+      }, {
+        "GQS": 22.72,
+        "Date": "2012-02-13",
+        "CBM": 7.55
+      }, {
+        "GQS": 21.59,
+        "Date": "2012-02-06",
+        "CBM": 7.08
+      }, {
+        "GQS": 21.71,
+        "Date": "2012-01-30",
+        "CBM": 8.24
+      }, {
+        "GQS": 18.93,
+        "Date": "2012-01-23",
+        "CBM": 7.97
+      }, {
+        "GQS": 18.63,
+        "Date": "2012-01-17",
+        "CBM": 7.58
+      }, {
+        "GQS": 18.26,
+        "Date": "2012-01-09",
+        "CBM": 7.52
+      }, {
+        "GQS": 18,
+        "Date": "2012-01-03",
+        "CBM": 7.9
+      }, {
+        "GQS": 18.55,
+        "Date": "2011-12-27",
+        "CBM": 7.18
+      }, {
+        "GQS": 18.61,
+        "Date": "2011-12-19",
+        "CBM": 7.4
+      }, {
+        "GQS": 18.3,
+        "Date": "2011-12-12",
+        "CBM": 7.61
+      }, {
+        "GQS": 18.85,
+        "Date": "2011-12-05",
+        "CBM": 7.38
+      }, {
+        "GQS": 18.7,
+        "Date": "2011-11-28",
+        "CBM": 7.1
+      }, {
+        "GQS": 17.62,
+        "Date": "2011-11-21",
+        "CBM": 6.21
+      }, {
+        "GQS": 18.76,
+        "Date": "2011-11-14",
+        "CBM": 6.29
+      }, {
+        "GQS": 20.33,
+        "Date": "2011-11-07",
+        "CBM": 6
+      }, {
+        "GQS": 19.65,
+        "Date": "2011-10-31",
+        "CBM": 5.63
+      }, {
+        "GQS": 19.33,
+        "Date": "2011-10-24",
+        "CBM": 5.66
+      }, {
+        "GQS": 18.71,
+        "Date": "2011-10-17",
+        "CBM": 5.46
+      }, {
+        "GQS": 17.78,
+        "Date": "2011-10-10",
+        "CBM": 5.52
+      }, {
+        "GQS": 17.3,
+        "Date": "2011-10-03",
+        "CBM": 4.9
+      }, {
+        "GQS": 16.24,
+        "Date": "2011-09-26",
+        "CBM": 5.04
+      }, {
+        "GQS": 16.31,
+        "Date": "2011-09-19",
+        "CBM": 4.8
+      }, {
+        "GQS": 17.04,
+        "Date": "2011-09-12",
+        "CBM": 5.35
+      }, {
+        "GQS": 16,
+        "Date": "2011-09-06",
+        "CBM": 4.86
+      }, {
+        "GQS": 15.6,
+        "Date": "2011-08-29",
+        "CBM": 4.7
+      }, {
+        "GQS": 16.28,
+        "Date": "2011-08-22",
+        "CBM": 4.54
+      }, {
+        "GQS": 15.69,
+        "Date": "2011-08-15",
+        "CBM": 4.31
+      }, {
+        "GQS": 16.49,
+        "Date": "2011-08-08",
+        "CBM": 4.81
+      }, {
+        "GQS": 16.75,
+        "Date": "2011-08-01",
+        "CBM": 4.8
+      }, {
+        "GQS": 19.29,
+        "Date": "2011-07-25",
+        "CBM": 4.41
+      }, {
+        "GQS": 19.66,
+        "Date": "2011-07-18",
+        "CBM": 4.94
+      }, {
+        "GQS": 18.91,
+        "Date": "2011-07-11",
+        "CBM": 5.09
+      }, {
+        "GQS": 18.98,
+        "Date": "2011-07-05",
+        "CBM": 4.93
+      }, {
+        "GQS": 18.28,
+        "Date": "2011-06-27",
+        "CBM": 4.76
+      }, {
+        "GQS": 17.66,
+        "Date": "2011-06-20",
+        "CBM": 4.29
+      }, {
+        "GQS": 17.83,
+        "Date": "2011-06-13",
+        "CBM": 4.07
+      }, {
+        "GQS": 17.72,
+        "Date": "2011-06-06",
+        "CBM": 4.24
+      }, {
+        "GQS": 17.92,
+        "Date": "2011-05-31",
+        "CBM": 4.47
+      }, {
+        "GQS": 19.2,
+        "Date": "2011-05-23",
+        "CBM": 4.82
+      }, {
+        "GQS": 19.22,
+        "Date": "2011-05-16",
+        "CBM": 4.78
+      }, {
+        "GQS": 23.05,
+        "Date": "2011-05-09",
+        "CBM": 5.04
+      }, {
+        "GQS": 22.6,
+        "Date": "2011-05-02",
+        "CBM": 4.6
+      }, {
+        "GQS": 23.24,
+        "Date": "2011-04-25",
+        "CBM": 5.26
+      }, {
+        "GQS": 21.99,
+        "Date": "2011-04-18",
+        "CBM": 5.01
+      }, {
+        "GQS": 22.47,
+        "Date": "2011-04-11",
+        "CBM": 5.04
+      }, {
+        "GQS": 22.25,
+        "Date": "2011-04-04",
+        "CBM": 5.05
+      }, {
+        "GQS": 22.63,
+        "Date": "2011-03-28",
+        "CBM": 5.5
+      }, {
+        "GQS": 22.56,
+        "Date": "2011-03-21",
+        "CBM": 5.36
+      }, {
+        "GQS": 21.87,
+        "Date": "2011-03-14",
+        "CBM": 4.61
+      }, {
+        "GQS": 21.97,
+        "Date": "2011-03-07",
+        "CBM": 5.05
+      }, {
+        "GQS": 21.59,
+        "Date": "2011-02-28",
+        "CBM": 5.43
+      }, {
+        "GQS": 22.75,
+        "Date": "2011-02-22",
+        "CBM": 5.54
+      }, {
+        "GQS": 23.05,
+        "Date": "2011-02-14",
+        "CBM": 5.61
+      }, {
+        "GQS": 21.4,
+        "Date": "2011-02-07",
+        "CBM": 5.95
+      }, {
+        "GQS": 20.1,
+        "Date": "2011-01-31",
+        "CBM": 4.94
+      }, {
+        "GQS": 19.2,
+        "Date": "2011-01-24",
+        "CBM": 4.71
+      }, {
+        "GQS": 20.1,
+        "Date": "2011-01-18",
+        "CBM": 4.88
+      }, {
+        "GQS": 20.41,
+        "Date": "2011-01-10",
+        "CBM": 5.23
+      }, {
+        "GQS": 20.51,
+        "Date": "2011-01-03",
+        "CBM": 5.01
+      }, {
+        "GQS": 22.14,
+        "Date": "2010-12-27",
+        "CBM": 5.17
+      }, {
+        "GQS": 21.46,
+        "Date": "2010-12-20",
+        "CBM": 5.92
+      }, {
+        "GQS": 21.19,
+        "Date": "2010-12-13",
+        "CBM": 5.85
+      }, {
+        "GQS": 21.48,
+        "Date": "2010-12-06",
+        "CBM": 4.98
+      }, {
+        "GQS": 21.44,
+        "Date": "2010-11-29",
+        "CBM": 4.33
+      }, {
+        "GQS": 20.9,
+        "Date": "2010-11-22",
+        "CBM": 4.2
+      }, {
+        "GQS": 20.7,
+        "Date": "2010-11-15",
+        "CBM": 4.31
+      }, {
+        "GQS": 20.49,
+        "Date": "2010-11-08",
+        "CBM": 4.25
+      }, {
+        "GQS": 20.81,
+        "Date": "2010-11-01",
+        "CBM": 4.27
+      }, {
+        "GQS": 19.01,
+        "Date": "2010-10-25",
+        "CBM": 4.53
+      }, {
+        "GQS": 19.15,
+        "Date": "2010-10-18",
+        "CBM": 4.44
+      }, {
+        "GQS": 19.52,
+        "Date": "2010-10-11",
+        "CBM": 4.74
+      }, {
+        "GQS": 18.21,
+        "Date": "2010-10-04",
+        "CBM": 4.17
+      }, {
+        "GQS": 18.51,
+        "Date": "2010-09-27",
+        "CBM": 4.1
+      }, {
+        "GQS": 18.83,
+        "Date": "2010-09-20",
+        "CBM": 4.41
+      }, {
+        "GQS": 18.91,
+        "Date": "2010-09-13",
+        "CBM": 4.01
+      }, {
+        "GQS": 17.37,
+        "Date": "2010-09-07",
+        "CBM": 4.12
+      }, {
+        "GQS": 17.65,
+        "Date": "2010-08-30",
+        "CBM": 4.3
+      }, {
+        "GQS": 17.03,
+        "Date": "2010-08-23",
+        "CBM": 4.06
+      }, {
+        "GQS": 17.32,
+        "Date": "2010-08-16",
+        "CBM": 4.36
+      }, {
+        "GQS": 17.67,
+        "Date": "2010-08-09",
+        "CBM": 3.8
+      }, {
+        "GQS": 18.28,
+        "Date": "2010-08-02",
+        "CBM": 3.97
+      }, {
+        "GQS": 18.11,
+        "Date": "2010-07-26",
+        "CBM": 3.55
+      }, {
+        "GQS": 18.41,
+        "Date": "2010-07-19",
+        "CBM": 3.5
+      }, {
+        "GQS": 18.13,
+        "Date": "2010-07-12",
+        "CBM": 3.11
+      }, {
+        "GQS": 18.53,
+        "Date": "2010-07-06",
+        "CBM": 3.11
+      }, {
+        "GQS": 19.48,
+        "Date": "2010-06-28",
+        "CBM": 2.98
+      }, {
+        "GQS": 20.2,
+        "Date": "2010-06-21",
+        "CBM": 3.4
+      }, {
+        "GQS": 21.24,
+        "Date": "2010-06-14",
+        "CBM": 3.75
+      }, {
+        "GQS": 21.99,
+        "Date": "2010-06-07",
+        "CBM": 3.71
+      }, {
+        "GQS": 20.96,
+        "Date": "2010-06-01",
+        "CBM": 3.78
+      }, {
+        "GQS": 21.8,
+        "Date": "2010-05-24",
+        "CBM": 4.17
+      }, {
+        "GQS": 22.15,
+        "Date": "2010-05-17",
+        "CBM": 4.36
+      }, {
+        "GQS": 22.96,
+        "Date": "2010-05-10",
+        "CBM": 4.46
+      }, {
+        "GQS": 22.27,
+        "Date": "2010-05-03",
+        "CBM": 4.25
+      }, {
+        "GQS": 24.73,
+        "Date": "2010-04-26",
+        "CBM": 4.39
+      }, {
+        "GQS": 26.06,
+        "Date": "2010-04-19",
+        "CBM": 4.3
+      }, {
+        "GQS": 25,
+        "Date": "2010-04-12",
+        "CBM": 4.42
+      }, {
+        "GQS": 24.85,
+        "Date": "2010-04-05",
+        "CBM": 4.37
+      }, {
+        "GQS": 23.63,
+        "Date": "2010-03-29",
+        "CBM": 4.11
+      }, {
+        "GQS": 23.42,
+        "Date": "2010-03-22",
+        "CBM": 3.88
+      }, {
+        "GQS": 23.22,
+        "Date": "2010-03-15",
+        "CBM": 4.25
+      }, {
+        "GQS": 22.8,
+        "Date": "2010-03-08",
+        "CBM": 4.23
+      }, {
+        "GQS": 22.32,
+        "Date": "2010-03-01",
+        "CBM": 4.24
+      }, {
+        "GQS": 21.5,
+        "Date": "2010-02-22",
+        "CBM": 3.77
+      }, {
+        "GQS": 19.85,
+        "Date": "2010-02-16",
+        "CBM": 4.11
+      }, {
+        "GQS": 19.95,
+        "Date": "2010-02-08",
+        "CBM": 4.31
+      }, {
+        "GQS": 19.88,
+        "Date": "2010-02-01",
+        "CBM": 5.19
+      }, {
+        "GQS": 19.08,
+        "Date": "2010-01-25",
+        "CBM": 5.38
+      }, {
+        "GQS": 18.86,
+        "Date": "2010-01-19",
+        "CBM": 5.74
+      }, {
+        "GQS": 19.56,
+        "Date": "2010-01-11",
+        "CBM": 5.83
+      }, {
+        "GQS": 20.4,
+        "Date": "2010-01-04",
+        "CBM": 5.68
+      }, {
+        "GQS": 20.95,
+        "Date": "2009-12-28",
+        "CBM": 5.58
+      }, {
+        "GQS": 20.71,
+        "Date": "2009-12-21",
+        "CBM": 5.69
+      }, {
+        "GQS": 20.89,
+        "Date": "2009-12-14",
+        "CBM": 5.43
+      }, {
+        "GQS": 21.46,
+        "Date": "2009-12-07",
+        "CBM": 5.35
+      }, {
+        "GQS": 21.77,
+        "Date": "2009-11-30",
+        "CBM": 5.48
+      }, {
+        "GQS": 22.03,
+        "Date": "2009-11-23",
+        "CBM": 5.7
+      }, {
+        "GQS": 21.95,
+        "Date": "2009-11-16",
+        "CBM": 5.86
+      }, {
+        "GQS": 22.42,
+        "Date": "2009-11-09",
+        "CBM": 6.15
+      }, {
+        "GQS": 23.03,
+        "Date": "2009-11-02",
+        "CBM": 6.27
+      }, {
+        "GQS": 21.34,
+        "Date": "2009-10-26",
+        "CBM": 6
+      }, {
+        "GQS": 22.02,
+        "Date": "2009-10-19",
+        "CBM": 6.78
+      }, {
+        "GQS": 22.96,
+        "Date": "2009-10-12",
+        "CBM": 6.95
+      }, {
+        "GQS": 22.24,
+        "Date": "2009-10-05",
+        "CBM": 6.77
+      }, {
+        "GQS": 20.81,
+        "Date": "2009-09-28",
+        "CBM": 6.12
+      }, {
+        "GQS": 21.48,
+        "Date": "2009-09-21",
+        "CBM": 6.15
+      }, {
+        "GQS": 22.02,
+        "Date": "2009-09-14",
+        "CBM": 6.43
+      }, {
+        "GQS": 21.6,
+        "Date": "2009-09-08",
+        "CBM": 6.06
+      }, {
+        "GQS": 21.12,
+        "Date": "2009-08-31",
+        "CBM": 5.72
+      }, {
+        "GQS": 19.93,
+        "Date": "2009-08-24",
+        "CBM": 5.52
+      }, {
+        "GQS": 19.48,
+        "Date": "2009-08-17",
+        "CBM": 5.36
+      }, {
+        "GQS": 18.78,
+        "Date": "2009-08-10",
+        "CBM": 4.66
+      }, {
+        "GQS": 18.58,
+        "Date": "2009-08-03",
+        "CBM": 4.58
+      }, {
+        "GQS": 16.32,
+        "Date": "2009-07-27",
+        "CBM": 4.58
+      }, {
+        "GQS": 15.94,
+        "Date": "2009-07-20",
+        "CBM": 4.46
+      }, {
+        "GQS": 16.17,
+        "Date": "2009-07-13",
+        "CBM": 4.4
+      }, {
+        "GQS": 14.96,
+        "Date": "2009-07-06",
+        "CBM": 4.1
+      }, {
+        "GQS": 15.39,
+        "Date": "2009-06-29",
+        "CBM": 4.05
+      }, {
+        "GQS": 16.06,
+        "Date": "2009-06-22",
+        "CBM": 4.48
+      }, {
+        "GQS": 15.8,
+        "Date": "2009-06-15",
+        "CBM": 4.2
+      }, {
+        "GQS": 16.37,
+        "Date": "2009-06-08",
+        "CBM": 4
+      }, {
+        "GQS": 16.63,
+        "Date": "2009-06-01",
+        "CBM": 4.1
+      }, {
+        "GQS": 17.85,
+        "Date": "2009-05-26",
+        "CBM": 3.6
+      }, {
+        "GQS": 16.39,
+        "Date": "2009-05-18",
+        "CBM": 3.91
+      }, {
+        "GQS": 15.16,
+        "Date": "2009-05-11",
+        "CBM": 3.71
+      }, {
+        "GQS": 16.55,
+        "Date": "2009-05-04",
+        "CBM": 4
+      }, {
+        "GQS": 15.77,
+        "Date": "2009-04-27",
+        "CBM": 2.45
+      }, {
+        "GQS": 15.28,
+        "Date": "2009-04-20",
+        "CBM": 2.58
+      }, {
+        "GQS": 15.12,
+        "Date": "2009-04-13",
+        "CBM": 2.78
+      }, {
+        "GQS": 15.09,
+        "Date": "2009-04-06",
+        "CBM": 2.84
+      }, {
+        "GQS": 15.25,
+        "Date": "2009-03-30",
+        "CBM": 2.3
+      }, {
+        "GQS": 13.06,
+        "Date": "2009-03-23",
+        "CBM": 2.48
+      }, {
+        "GQS": 11.98,
+        "Date": "2009-03-16",
+        "CBM": 2.49
+      }, {
+        "GQS": 11.99,
+        "Date": "2009-03-09",
+        "CBM": 1.75
+      }, {
+        "GQS": 9.85,
+        "Date": "2009-03-02",
+        "CBM": 1.5
+      }, {
+        "GQS": 10.79,
+        "Date": "2009-02-23",
+        "CBM": 2.16
+      }, {
+        "GQS": 11.55,
+        "Date": "2009-02-17",
+        "CBM": 3.3
+      }, {
+        "GQS": 11.62,
+        "Date": "2009-02-09",
+        "CBM": 3.98
+      }, {
+        "GQS": 11.94,
+        "Date": "2009-02-02",
+        "CBM": 4.62
+      }, {
+        "GQS": 11.28,
+        "Date": "2009-01-26",
+        "CBM": 3.27
+      }, {
+        "GQS": 12,
+        "Date": "2009-01-20",
+        "CBM": 3.5
+      }, {
+        "GQS": 12.14,
+        "Date": "2009-01-12",
+        "CBM": 4.3
+      }, {
+        "GQS": 12.99,
+        "Date": "2009-01-05",
+        "CBM": 4.45
+      }, {
+        "GQS": 14.07,
+        "Date": "2008-12-29",
+        "CBM": 4.35
+      }, {
+        "GQS": 12.97,
+        "Date": "2008-12-22",
+        "CBM": 4.52
+      }, {
+        "GQS": 13.57,
+        "Date": "2008-12-15",
+        "CBM": 4.63
+      }, {
+        "GQS": 13.19,
+        "Date": "2008-12-08",
+        "CBM": 3.86
+      }, {
+        "GQS": 14.01,
+        "Date": "2008-12-01",
+        "CBM": 3.69
+      }, {
+        "GQS": 13.02,
+        "Date": "2008-11-24",
+        "CBM": 3.48
+      }, {
+        "GQS": 12.1,
+        "Date": "2008-11-17",
+        "CBM": 2.5
+      }, {
+        "GQS": 11.55,
+        "Date": "2008-11-10",
+        "CBM": 2.94
+      }, {
+        "GQS": 12.82,
+        "Date": "2008-11-03",
+        "CBM": 3.88
+      }, {
+        "GQS": 12.94,
+        "Date": "2008-10-27",
+        "CBM": 4.5
+      }, {
+        "GQS": 11.21,
+        "Date": "2008-10-20",
+        "CBM": 4.59
+      }, {
+        "GQS": 13.42,
+        "Date": "2008-10-13",
+        "CBM": 4.98
+      }, {
+        "GQS": 13.82,
+        "Date": "2008-10-06",
+        "CBM": 4.36
+      }, {
+        "GQS": 16.83,
+        "Date": "2008-09-29",
+        "CBM": 4.59
+      }, {
+        "GQS": 18.37,
+        "Date": "2008-09-22",
+        "CBM": 6.38
+      }, {
+        "GQS": 19.08,
+        "Date": "2008-09-15",
+        "CBM": 6.6
+      }, {
+        "GQS": 19.37,
+        "Date": "2008-09-08",
+        "CBM": 6.48
+      }, {
+        "GQS": 19.19,
+        "Date": "2008-09-02",
+        "CBM": 6.24
+      }, {
+        "GQS": 19.45,
+        "Date": "2008-08-25",
+        "CBM": 6.51
+      }, {
+        "GQS": 19.88,
+        "Date": "2008-08-18",
+        "CBM": 6.73
+      }, {
+        "GQS": 19.4,
+        "Date": "2008-08-11",
+        "CBM": 6.74
+      }, {
+        "GQS": 18.09,
+        "Date": "2008-08-04",
+        "CBM": 6.6
+      }, {
+        "GQS": 16.34,
+        "Date": "2008-07-28",
+        "CBM": 7.69
+      }, {
+        "GQS": 16.29,
+        "Date": "2008-07-21",
+        "CBM": 7.89
+      }, {
+        "GQS": 16.6,
+        "Date": "2008-07-14",
+        "CBM": 6.83
+      }, {
+        "GQS": 15.25,
+        "Date": "2008-07-07",
+        "CBM": 6.03
+      }, {
+        "GQS": 16.45,
+        "Date": "2008-06-30",
+        "CBM": 5.45
+      }, {
+        "GQS": 16.74,
+        "Date": "2008-06-23",
+        "CBM": 5.98
+      }, {
+        "GQS": 17.45,
+        "Date": "2008-06-16",
+        "CBM": 6.48
+      }, {
+        "GQS": 18,
+        "Date": "2008-06-09",
+        "CBM": 6.32
+      }, {
+        "GQS": 17.17,
+        "Date": "2008-06-02",
+        "CBM": 6.35
+      }, {
+        "GQS": 18.25,
+        "Date": "2008-05-27",
+        "CBM": 6.15
+      }, {
+        "GQS": 17.94,
+        "Date": "2008-05-19",
+        "CBM": 5.59
+      }, {
+        "GQS": 18.43,
+        "Date": "2008-05-12",
+        "CBM": 5.99
+      }, {
+        "GQS": 17.94,
+        "Date": "2008-05-05",
+        "CBM": 5.51
+      }, {
+        "GQS": 18.68,
+        "Date": "2008-04-28",
+        "CBM": 5.96
+      }, {
+        "GQS": 19.34,
+        "Date": "2008-04-21",
+        "CBM": 5.97
+      }, {
+        "GQS": 19,
+        "Date": "2008-04-14",
+        "CBM": 5.95
+      }, {
+        "GQS": 17.95,
+        "Date": "2008-04-07",
+        "CBM": 6.2
+      }, {
+        "GQS": 19.05,
+        "Date": "2008-03-31",
+        "CBM": 7.09
+      }, {
+        "GQS": 19.52,
+        "Date": "2008-03-24",
+        "CBM": 6.94
+      }, {
+        "GQS": 21.37,
+        "Date": "2008-03-17",
+        "CBM": 8.01
+      }, {
+        "GQS": 19.81,
+        "Date": "2008-03-10",
+        "CBM": 7.83
+      }, {
+        "GQS": 19.58,
+        "Date": "2008-03-03",
+        "CBM": 7.94
+      }, {
+        "GQS": 20.17,
+        "Date": "2008-02-25",
+        "CBM": 8.73
+      }, {
+        "GQS": 19.71,
+        "Date": "2008-02-19",
+        "CBM": 9.48
+      }, {
+        "GQS": 19.7,
+        "Date": "2008-02-11",
+        "CBM": 9.84
+      }, {
+        "GQS": 19.78,
+        "Date": "2008-02-04",
+        "CBM": 10.46
+      }, {
+        "GQS": 19.34,
+        "Date": "2008-01-28",
+        "CBM": 9.73
+      }, {
+        "GQS": 17.8,
+        "Date": "2008-01-22",
+        "CBM": 9.32
+      }, {
+        "GQS": 17.23,
+        "Date": "2008-01-14",
+        "CBM": 9.76
+      }, {
+        "GQS": 17.2,
+        "Date": "2008-01-07",
+        "CBM": 8.57
+      }, {
+        "GQS": 19.66,
+        "Date": "2007-12-31",
+        "CBM": 7.8
+      }, {
+        "GQS": 21.36,
+        "Date": "2007-12-24",
+        "CBM": 8.36
+      }, {
+        "GQS": 21.76,
+        "Date": "2007-12-17",
+        "CBM": 9.03
+      }, {
+        "GQS": 21.18,
+        "Date": "2007-12-10",
+        "CBM": 8.5
+      }, {
+        "GQS": 21.57,
+        "Date": "2007-12-03",
+        "CBM": 8.24
+      }, {
+        "GQS": 20.4,
+        "Date": "2007-11-26",
+        "CBM": 7.74
+      }, {
+        "GQS": 18.89,
+        "Date": "2007-11-19",
+        "CBM": 7.71
+      }, {
+        "GQS": 20.09,
+        "Date": "2007-11-12",
+        "CBM": 7.97
+      }, {
+        "GQS": 19.38,
+        "Date": "2007-11-05",
+        "CBM": 9.17
+      }, {
+        "GQS": 18.21,
+        "Date": "2007-10-29",
+        "CBM": 10.52
+      }, {
+        "GQS": 18.61,
+        "Date": "2007-10-22",
+        "CBM": 11.37
+      }, {
+        "GQS": 17.75,
+        "Date": "2007-10-15",
+        "CBM": 10.67
+      }, {
+        "GQS": 19.01,
+        "Date": "2007-10-08",
+        "CBM": 11.45
+      }, {
+        "GQS": 18.91,
+        "Date": "2007-10-01",
+        "CBM": 10.88
+      }, {
+        "GQS": 18.44,
+        "Date": "2007-09-24",
+        "CBM": 10.89
+      }, {
+        "GQS": 18.55,
+        "Date": "2007-09-17",
+        "CBM": 12.06
+      }, {
+        "GQS": 18,
+        "Date": "2007-09-10",
+        "CBM": 11.33
+      }, {
+        "GQS": 17.94,
+        "Date": "2007-09-04",
+        "CBM": 11.42
+      }, {
+        "GQS": 18.76,
+        "Date": "2007-08-27",
+        "CBM": 12.47
+      }, {
+        "GQS": 18.51,
+        "Date": "2007-08-20",
+        "CBM": 12.83
+      }, {
+        "GQS": 17.27,
+        "Date": "2007-08-13",
+        "CBM": 13.38
+      }, {
+        "GQS": 16.75,
+        "Date": "2007-08-06",
+        "CBM": 11.81
+      }, {
+        "GQS": 16.44,
+        "Date": "2007-07-30",
+        "CBM": 12.96
+      }, {
+        "GQS": 17.79,
+        "Date": "2007-07-23",
+        "CBM": 13.3
+      }, {
+        "GQS": 18.63,
+        "Date": "2007-07-16",
+        "CBM": 13.69
+      }, {
+        "GQS": 18.56,
+        "Date": "2007-07-09",
+        "CBM": 14.35
+      }, {
+        "GQS": 19.22,
+        "Date": "2007-07-02",
+        "CBM": 13.58
+      }, {
+        "GQS": 19.1,
+        "Date": "2007-06-25",
+        "CBM": 13.27
+      }, {
+        "GQS": 19.34,
+        "Date": "2007-06-18",
+        "CBM": 13.45
+      }, {
+        "GQS": 18.97,
+        "Date": "2007-06-11",
+        "CBM": 13.4
+      }, {
+        "GQS": 18.47,
+        "Date": "2007-06-04",
+        "CBM": 12.69
+      }, {
+        "GQS": 18.51,
+        "Date": "2007-05-29",
+        "CBM": 12.53
+      }, {
+        "GQS": 18.18,
+        "Date": "2007-05-21",
+        "CBM": 12.53
+      }, {
+        "GQS": 18.44,
+        "Date": "2007-05-14",
+        "CBM": 12.53
+      }, {
+        "GQS": 18.32,
+        "Date": "2007-05-07",
+        "CBM": 12.13
+      }, {
+        "GQS": 18.5,
+        "Date": "2007-04-30",
+        "CBM": 11.67
+      }, {
+        "GQS": 18.31,
+        "Date": "2007-04-23",
+        "CBM": 24.56
+      }, {
+        "GQS": 18.96,
+        "Date": "2007-04-16",
+        "CBM": 25.04
+      }, {
+        "GQS": 18.47,
+        "Date": "2007-04-09",
+        "CBM": 25.45
+      }, {
+        "GQS": 17.64,
+        "Date": "2007-04-02",
+        "CBM": 24.97
+      }, {
+        "GQS": 17.21,
+        "Date": "2007-03-26",
+        "CBM": 24.6
+      }, {
+        "GQS": 17.85,
+        "Date": "2007-03-19",
+        "CBM": 24.84
+      }, {
+        "GQS": 17.5,
+        "Date": "2007-03-12",
+        "CBM": 24.5
+      }, {
+        "GQS": 17.84,
+        "Date": "2007-03-05",
+        "CBM": 23.13
+      }, {
+        "GQS": 18.4,
+        "Date": "2007-02-26",
+        "CBM": 22.67
+      }, {
+        "GQS": 19.81,
+        "Date": "2007-02-20",
+        "CBM": 23.49
+      }, {
+        "GQS": 20.02,
+        "Date": "2007-02-12",
+        "CBM": 23.5
+      }, {
+        "GQS": 19.55,
+        "Date": "2007-02-05",
+        "CBM": 23.38
+      }, {
+        "GQS": 19.47,
+        "Date": "2007-01-29",
+        "CBM": 21.92
+      }, {
+        "GQS": 19.04,
+        "Date": "2007-01-22",
+        "CBM": 21.46
+      }, {
+        "GQS": 20,
+        "Date": "2007-01-16",
+        "CBM": 22.05
+      }, {
+        "GQS": 20.3,
+        "Date": "2007-01-08",
+        "CBM": 22.33
+      }, {
+        "GQS": 18.89,
+        "Date": "2007-01-03",
+        "CBM": 22.37
+      }, {
+        "GQS": 19.5,
+        "Date": "2006-12-26",
+        "CBM": 22.72
+      }, {
+        "GQS": 19.95,
+        "Date": "2006-12-18",
+        "CBM": 22.88
+      }, {
+        "GQS": 20.39,
+        "Date": "2006-12-11",
+        "CBM": 22.39
+      }, {
+        "GQS": 19.66,
+        "Date": "2006-12-04",
+        "CBM": 22.6
+      }, {
+        "GQS": 18.68,
+        "Date": "2006-11-27",
+        "CBM": 22.12
+      }, {
+        "GQS": 19.3,
+        "Date": "2006-11-20",
+        "CBM": 22.31
+      }, {
+        "GQS": 19.81,
+        "Date": "2006-11-13",
+        "CBM": 22.39
+      }, {
+        "GQS": 20.19,
+        "Date": "2006-11-06",
+        "CBM": 22.66
+      }, {
+        "GQS": 19.57,
+        "Date": "2006-10-30",
+        "CBM": 22.67
+      }, {
+        "GQS": 20.72,
+        "Date": "2006-10-23",
+        "CBM": 23.88
+      }, {
+        "GQS": 19.3,
+        "Date": "2006-10-16",
+        "CBM": 21.53
+      }, {
+        "GQS": 19.85,
+        "Date": "2006-10-09",
+        "CBM": 21.59
+      }, {
+        "GQS": 19.07,
+        "Date": "2006-10-02",
+        "CBM": 21.37
+      }, {
+        "GQS": 18.95,
+        "Date": "2006-09-25",
+        "CBM": 20.71
+      }, {
+        "GQS": 18.39,
+        "Date": "2006-09-18",
+        "CBM": 21.05
+      }, {
+        "GQS": 17.92,
+        "Date": "2006-09-11",
+        "CBM": 21.7
+      }, {
+        "GQS": 16.9,
+        "Date": "2006-09-05",
+        "CBM": 21.18
+      }, {
+        "GQS": 16.9,
+        "Date": "2006-08-28",
+        "CBM": 22.76
+      }, {
+        "GQS": 16.61,
+        "Date": "2006-08-21",
+        "CBM": 21.52
+      }, {
+        "GQS": 16.65,
+        "Date": "2006-08-14",
+        "CBM": 21.13
+      }, {
+        "GQS": 16.9,
+        "Date": "2006-08-07",
+        "CBM": 19.78
+      }, {
+        "GQS": 16.75,
+        "Date": "2006-07-31",
+        "CBM": 20.94
+      }, {
+        "GQS": 17.12,
+        "Date": "2006-07-24",
+        "CBM": 21.59
+      }]
+    },
+    "created": "2017-05-24T03:21:07.631Z",
+    "updated": "2017-05-24T03:21:20.890Z",
+    "author": null,
+    "creator": null,
+    "icon": "",
+    "description": null
+  }
+}, {
+  "model": "chartwerk.template",
+  "pk": 6,
+  "fields": {
+    "slug": "us-choropleth-map",
+    "title": "US choropleth map",
+    "data": {
+      "text": {
+        "chatter": "States that are either open or closed.",
+        "annotations": [],
+        "source": "SOURCE: New York Stock Exchange",
+        "legend": {
+          "single": {
+            "inside": false,
+            "position": {
+              "x": 10,
+              "y": 10
+            },
+            "align": "l",
+            "background": true,
+            "width": 250
+          },
+          "double": {
+            "inside": false,
+            "position": {
+              "x": 10,
+              "y": 10
+            },
+            "align": "l",
+            "background": true,
+            "width": 500
+          },
+          "title": "",
+          "active": false,
+          "keys": [{
+            "text": "",
+            "color": "#329CEB"
+          }, {
+            "text": "",
+            "color": "#52B033"
+          }]
+        },
+        "author": "John Doe / DMN",
+        "headline": "State-craft",
+        "title": "",
+        "footnote": ""
+      },
+      "template": {
+        "icon": null,
+        "tags": [],
+        "description": "Use this map if you want to compare states.\n\nYour data must include a column of state names, either as full text, like \"Texas,\" or as postal abbreviations, like \"TX.\" This column should be classified as a \"Base axis.\"\n\nYou should classify your value column as a \"Scale column\" on the data tab.",
+        "title": "US state choropleth map"
+      },
+      "embed": {
+        "dimensions": {}
+      },
+      "scripts": {
+        "helper": "var werkHelper = {\n    prototype: function() {\n        d3.selection.prototype.moveToFront = function() {\n          return this.each(function(){\n            this.parentNode.appendChild(this);\n          });\n        };\n    },\n    \n    parse: function(werk){\n        werk.data = chartwerk.data.map(function(d){\n            return {\n                state: d[chartwerk.datamap.base],\n                value: chartwerk.axes.color.quantize ? \n                    +d[chartwerk.datamap.scale] : d[chartwerk.datamap.scale],\n                tooltip: chartwerk.datamap.custom.tooltip !== '' ?\n                    d[chartwerk.datamap.custom.tooltip] : null,\n            };\n        });\n    },\n    \n    dims: function(werk){\n        var s = chartwerk.ui.size;\n            w = werk.dims[s].width,\n            h = werk.dims[s].height,\n            margins = {\n                right: chartwerk.margins[s].right * w,\n                left: chartwerk.margins[s].left * w,\n                top: chartwerk.margins[s].top * h,\n                bottom: chartwerk.margins[s].bottom * h\n            },\n            svg = {\n                width: w - margins.left - margins.right,\n                height: h - margins.top - margins.bottom\n            };\n        \n        werk.dims.margins = margins;\n        werk.dims.svg = svg;\n    },\n\n    scales: function(werk){\n        var svg = werk.dims.svg;\n        werk.scales = {\n            color: chartwerk.axes.color.quantize ? \n                d3.scaleThreshold() : d3.scaleOrdinal(),\n        };\n        \n        werk.scales.color\n            .domain(chartwerk.axes.color.domain)\n            .range(chartwerk.axes.color.range);\n    },\n\n    // Build dims, scales and axes.\n    build: function(werk){\n        this.prototype();\n        this.parse(werk);\n        this.dims(werk);\n        this.scales(werk);\n        return werk;\n    },\n};\n\n",
+        "draw": "function draw(){\n    var initialProps = {\n        dims: {\n          single: { width: 270, height: 205 },\n          double: { width: 580, height: 370}\n        },\n    };\n    \n    var werk = werkHelper.build(initialProps);\n\t\n\tvar comma = d3.format(\",\");\n\n    var map = d3.map(werk.data, function(d){ return d.state; }),\n        path = d3.geoPath(),\n        postal = werk.data[0].state.length === 2; // If state label is a postal code\n\t\n\tvar svg = d3.select(\"#chart\").append(\"svg\")\n      .style(\"background-color\",\"transparent\")\n        .attr(\"width\", werk.dims.svg.width + werk.dims.margins.left + werk.dims.margins.right)\n        .attr(\"height\", werk.dims.svg.height + werk.dims.margins.top + werk.dims.margins.bottom)\n      .append(\"g\")\n        .attr(\"transform\", \"translate(\" + werk.dims.margins.left + \",\" + werk.dims.margins.top + \")\");\n    \n    var projection = d3.geoAlbersUsa()\n        // Scale for different sizes\n        .scale(chartwerk.ui.size === 'double' ? 720 : 350);\n\n    function getState(d){\n        return postal ? map.get(d.properties.ABBREVIATION) : map.get(d.properties.NAME);\n    }\n    \n    d3.json(\"//interactives.dallasnews.com/common/data/geo/us-states.json\", function(error, us_states){\n\n        var states = svg.append(\"g\")\n            .attr(\"id\", \"states\")\n            // Have to recenter, probably because this map originally had Puerto Rico in it...\n            .attr(\"transform\", chartwerk.ui.size === 'double' ? \"translate(-220, -90)\" : \"translate(-360, -160)\")\n            .selectAll(\"path\")\n            .data(topojson.feature(us_states, us_states.objects.us_states).features)\n            .enter().append(\"path\")\n            .attr('d', d3.geoPath().projection(projection))\n            .attr(\"class\", \"state\")\n            .style('fill', function(d){ \n                return werk.scales.color(getState(d).value);\n            })\n            .style(\"stroke\", \"#fff\")\n            .on(\"mouseover\",function(d){\n                d3.select(this)\n                  .style(\"stroke\", \"black\")\n                  .moveToFront();\n                d3.select(\".tooltip .title\")\n                  .text(d.properties.NAME);\n                d3.select(\".tooltip .value\")\n                  .text(function(){\n                      var s = chartwerk.axes.scale;\n                      var data = getState(d);\n                      if (data.tooltip){\n                          return data.tooltip;\n                      } else {\n                          return chartwerk.axes.color.quantize ? \n                            s.prefix + comma(data.value) + s.suffix : data.value;\n                      }\n                  });\n                var p = d3.mouse(this.parentElement.parentElement);\n                d3.select(\".tooltip\")\n                    .style(\"opacity\", 1)\n                    .style(\"top\",function(){\n                        return p[1].toString() + \"px\";\n                    })\n                    .style(\"left\", function(){\n                        // We position either left or right of the mouse point based\n                        // on whether we're past the midpoint of the chart. This protects\n                        // against tooltips overflowing embedded iframes.\n                        var s = chartwerk.ui.size,\n                            w = werk.dims[s].width,\n                            tipW = parseInt(d3.select(\".tooltip\").style(\"width\"), 10),\n                            pos = p[0] > (w / 2) ?\n                                p[0] - (tipW - 10) : p[0] + 40;\n                        return pos.toString() + \"px\";\n                    });\n            })\n            .on(\"mouseout\",function(){\n                d3.select(this)\n                  .style(\"stroke\",\"#fff\")\n                  .style('fill', function(d){ \n                      return werk.scales.color(getState(d).value);\n                });\n                d3.select(\".tooltip\")\n                    .style(\"opacity\", 0);\n            });\n    });\n    \n    var tooltip = d3.select(\"#chart\")\n      .append(\"div\")\n        .attr(\"class\",\"tooltip\")\n        .style(\"position\",\"absolute\");\n    tooltip\n      .append(\"div\")\n      .attr(\"class\",\"title\")\n      .text(chartwerk.datamap.scale);\n    tooltip\n      .append(\"div\")\n      .attr(\"class\",\"value\");\n}",
+        "styles": "#chartwerk {\n    font-family:'Gotham A', 'Gotham B', arial, sans-serif; \n    width:600px;\n}\n#chartwerk #chart {\n    background: white;\n}\n#chartwerk.single{\n    width:290px;\n    float:left;\n    overflow:hidden;\n    margin:10px 30px 10px 0;\n}\n#chartwerk #headline { \n    font-weight:bold;\n    font-size:24px;\n}\n#chartwerk #chatter {\n    margin-top:5px;\n}\n#chartwerk #footnote,\n#chartwerk #source,\n#chartwerk #author {\n    font-size:11px;\n    color:grey;\n\n}\n#chartwerk #author {\n    text-align:right;\n}\n\n#chartwerk #chart-legend \n.chart-legend-container .key-label{\n    font:11px 'Gotham A', 'Gotham B', arial, sans-serif;\n}\n#chartwerk #chart path.line{\n    fill: none;\n    stroke-width: 2px;\n}\n#chartwerk #chart-legend{\n    margin-top:10px;\n}\n\n#chartwerk #chart path.state{\n    stroke-width:1px;\n    cursor:crosshair;\n}\n#chartwerk #chart{\n    position:relative;\n}\n#chartwerk #chart .tooltip{\n    font: 13px 'Gotham A', 'Gotham B', arial, sans-serif;\n    opacity:0;\n    pointer-events:none;\n    background:rgba(255,255,255,.75);\n    padding:5px;\n    width:auto;\n}\n#chartwerk #chart .tooltip .title{\n    font-weight: bold;\n    fill:grey;\n}",
+        "dependencies": {
+          "styles": ["https://cloud.typography.com/6922714/7642152/css/fonts.css", "https://interactives.dallasnews.com/common/fonts/gotham.css"],
+          "scripts": ["https://cdnjs.cloudflare.com/ajax/libs/d3/4.2.3/d3.min.js", "https://cdnjs.cloudflare.com/ajax/libs/topojson/1.6.20/topojson.min.js"]
+        },
+        "html": "<div id='chart-header'>\n\t<h2 id='headline'></h2>\n\t<div id='chatter'></div> \n</div> \n<div id='chart-ui'>\n\t<!--You can put any necessary buttons, etc., here.-->\n</div>\n<div id='chart-legend'></div>\n<div id='chart'></div> \n<div id='chart-footer'> \n\t<div id='footnote'></div> \n\t<div id='source'></div> \n\t<div id='author'></div> \n</div>"
+      },
+      "datamap": {
+        "value": null,
+        "custom": {
+          "tooltip": "Tooltip"
+        },
+        "ignore": [],
+        "scale": "Status",
+        "series": [],
+        "sort": ["State", "Status", "Tooltip"],
+        "facet": null,
+        "base": "State"
+      },
+      "axes": {
+        "color": {
+          "ignoreScale": false,
+          "domain": ["closed", "open"],
+          "byFacet": false,
+          "quantizeProps": {
+            "reverseColors": false,
+            "groups": 0,
+            "column": null
+          },
+          "scheme": "categorical.default",
+          "quantize": false,
+          "range": ["#329CEB", "#52B033"]
+        },
+        "value": {
+          "prefix": "$",
+          "suffix": "",
+          "min": null,
+          "shadedRegions": [],
+          "label": "",
+          "max": null,
+          "format": {
+            "single": {
+              "customTicks": [],
+              "ticks": 7
+            },
+            "double": {
+              "customTicks": [],
+              "ticks": 7
+            }
+          }
+        },
+        "scale": {
+          "prefix": "",
+          "suffix": ""
+        },
+        "base": {
+          "prefix": "",
+          "type": "categorical",
+          "suffix": "",
+          "min": null,
+          "shadedRegions": [],
+          "label": "",
+          "max": null,
+          "dateFormat": null,
+          "format": {
+            "single": {
+              "customTicks": [],
+              "dateString": "Y",
+              "ticks": 7,
+              "frequency": 2
+            },
+            "double": {
+              "customTicks": [],
+              "dateString": "Y",
+              "ticks": 7,
+              "frequency": 1
+            }
+          }
+        }
+      },
+      "ui": {
+        "size": "double",
+        "rawData": "State\tStatus\tTooltip\nAL\tclosed\tThis state is closed\nAK\tclosed\tThis state is closed\nAZ\topen\tThis state is open\nAR\tclosed\tThis state is closed\nCA\tclosed\tThis state is closed\nCO\tclosed\tThis state is closed\nCT\tclosed\tThis state is closed\nDE\tclosed\tThis state is closed\nFL\tclosed\tThis state is closed\nGA\topen\tThis state is open\nHI\tclosed\tThis state is closed\nID\tclosed\tThis state is closed\nIL\tclosed\tThis state is closed\nIN\tclosed\tThis state is closed\nIA\tclosed\tThis state is closed\nKS\topen\tThis state is open\nKY\tclosed\tThis state is closed\nLA\tclosed\tThis state is closed\nME\tclosed\tThis state is closed\nMD\topen\tThis state is open\nMA\tclosed\tThis state is closed\nMI\tclosed\tThis state is closed\nMN\topen\tThis state is open\nMS\tclosed\tThis state is closed\nMO\tclosed\tThis state is closed\nMT\tclosed\tThis state is closed\nNE\topen\tThis state is open\nNV\tclosed\tThis state is closed\nNH\tclosed\tThis state is closed\nNJ\topen\tThis state is open\nNM\tclosed\tThis state is closed\nNY\tclosed\tThis state is closed\nNC\tclosed\tThis state is closed\nND\topen\tThis state is open\nOH\topen\tThis state is open\nOK\tclosed\tThis state is closed\nOR\topen\tThis state is open\nPA\topen\tThis state is open\nRI\tclosed\tThis state is closed\nSC\tclosed\tThis state is closed\nSD\tclosed\tThis state is closed\nTN\topen\tThis state is open\nTX\tclosed\tThis state is closed\nUT\tclosed\tThis state is closed\nVT\tclosed\tThis state is closed\nVA\tclosed\tThis state is closed\nWA\tclosed\tThis state is closed\nWV\tclosed\tThis state is closed\nWI\tclosed\tThis state is closed\nWY\tclosed\tThis state is closed\n",
+        "datamap": [{
+          "available": true,
+          "class": "base",
+          "alias": "State"
+        }, {
+          "available": false,
+          "class": "value",
+          "alias": "value axis"
+        }, {
+          "available": true,
+          "class": "scale",
+          "alias": "Color value"
+        }, {
+          "available": false,
+          "class": "series",
+          "alias": "data series"
+        }, {
+          "available": false,
+          "class": "facet",
+          "alias": "faceting column"
+        }, {
+          "available": false,
+          "class": "ignore",
+          "alias": "ignored column"
+        }, {
+          "available": true,
+          "class": "tooltip",
+          "alias": "Tooltip"
+        }]
+      },
+      "margins": {
+        "single": {
+          "left": 0.05,
+          "top": 0.05,
+          "right": 0.050000000000000044,
+          "bottom": 0.050000000000000044
+        },
+        "double": {
+          "left": 0.05,
+          "top": 0.05,
+          "right": 0.050000000000000044,
+          "bottom": 0.050000000000000044
+        }
+      },
+      "data": [{
+        "Tooltip": "This state is closed",
+        "State": "AL",
+        "Status": "closed"
+      }, {
+        "Tooltip": "This state is closed",
+        "State": "AK",
+        "Status": "closed"
+      }, {
+        "Tooltip": "This state is open",
+        "State": "AZ",
+        "Status": "open"
+      }, {
+        "Tooltip": "This state is closed",
+        "State": "AR",
+        "Status": "closed"
+      }, {
+        "Tooltip": "This state is closed",
+        "State": "CA",
+        "Status": "closed"
+      }, {
+        "Tooltip": "This state is closed",
+        "State": "CO",
+        "Status": "closed"
+      }, {
+        "Tooltip": "This state is closed",
+        "State": "CT",
+        "Status": "closed"
+      }, {
+        "Tooltip": "This state is closed",
+        "State": "DE",
+        "Status": "closed"
+      }, {
+        "Tooltip": "This state is closed",
+        "State": "FL",
+        "Status": "closed"
+      }, {
+        "Tooltip": "This state is open",
+        "State": "GA",
+        "Status": "open"
+      }, {
+        "Tooltip": "This state is closed",
+        "State": "HI",
+        "Status": "closed"
+      }, {
+        "Tooltip": "This state is closed",
+        "State": "ID",
+        "Status": "closed"
+      }, {
+        "Tooltip": "This state is closed",
+        "State": "IL",
+        "Status": "closed"
+      }, {
+        "Tooltip": "This state is closed",
+        "State": "IN",
+        "Status": "closed"
+      }, {
+        "Tooltip": "This state is closed",
+        "State": "IA",
+        "Status": "closed"
+      }, {
+        "Tooltip": "This state is open",
+        "State": "KS",
+        "Status": "open"
+      }, {
+        "Tooltip": "This state is closed",
+        "State": "KY",
+        "Status": "closed"
+      }, {
+        "Tooltip": "This state is closed",
+        "State": "LA",
+        "Status": "closed"
+      }, {
+        "Tooltip": "This state is closed",
+        "State": "ME",
+        "Status": "closed"
+      }, {
+        "Tooltip": "This state is open",
+        "State": "MD",
+        "Status": "open"
+      }, {
+        "Tooltip": "This state is closed",
+        "State": "MA",
+        "Status": "closed"
+      }, {
+        "Tooltip": "This state is closed",
+        "State": "MI",
+        "Status": "closed"
+      }, {
+        "Tooltip": "This state is open",
+        "State": "MN",
+        "Status": "open"
+      }, {
+        "Tooltip": "This state is closed",
+        "State": "MS",
+        "Status": "closed"
+      }, {
+        "Tooltip": "This state is closed",
+        "State": "MO",
+        "Status": "closed"
+      }, {
+        "Tooltip": "This state is closed",
+        "State": "MT",
+        "Status": "closed"
+      }, {
+        "Tooltip": "This state is open",
+        "State": "NE",
+        "Status": "open"
+      }, {
+        "Tooltip": "This state is closed",
+        "State": "NV",
+        "Status": "closed"
+      }, {
+        "Tooltip": "This state is closed",
+        "State": "NH",
+        "Status": "closed"
+      }, {
+        "Tooltip": "This state is open",
+        "State": "NJ",
+        "Status": "open"
+      }, {
+        "Tooltip": "This state is closed",
+        "State": "NM",
+        "Status": "closed"
+      }, {
+        "Tooltip": "This state is closed",
+        "State": "NY",
+        "Status": "closed"
+      }, {
+        "Tooltip": "This state is closed",
+        "State": "NC",
+        "Status": "closed"
+      }, {
+        "Tooltip": "This state is open",
+        "State": "ND",
+        "Status": "open"
+      }, {
+        "Tooltip": "This state is open",
+        "State": "OH",
+        "Status": "open"
+      }, {
+        "Tooltip": "This state is closed",
+        "State": "OK",
+        "Status": "closed"
+      }, {
+        "Tooltip": "This state is open",
+        "State": "OR",
+        "Status": "open"
+      }, {
+        "Tooltip": "This state is open",
+        "State": "PA",
+        "Status": "open"
+      }, {
+        "Tooltip": "This state is closed",
+        "State": "RI",
+        "Status": "closed"
+      }, {
+        "Tooltip": "This state is closed",
+        "State": "SC",
+        "Status": "closed"
+      }, {
+        "Tooltip": "This state is closed",
+        "State": "SD",
+        "Status": "closed"
+      }, {
+        "Tooltip": "This state is open",
+        "State": "TN",
+        "Status": "open"
+      }, {
+        "Tooltip": "This state is closed",
+        "State": "TX",
+        "Status": "closed"
+      }, {
+        "Tooltip": "This state is closed",
+        "State": "UT",
+        "Status": "closed"
+      }, {
+        "Tooltip": "This state is closed",
+        "State": "VT",
+        "Status": "closed"
+      }, {
+        "Tooltip": "This state is closed",
+        "State": "VA",
+        "Status": "closed"
+      }, {
+        "Tooltip": "This state is closed",
+        "State": "WA",
+        "Status": "closed"
+      }, {
+        "Tooltip": "This state is closed",
+        "State": "WV",
+        "Status": "closed"
+      }, {
+        "Tooltip": "This state is closed",
+        "State": "WI",
+        "Status": "closed"
+      }, {
+        "Tooltip": "This state is closed",
+        "State": "WY",
+        "Status": "closed"
+      }]
+    },
+    "created": "2017-05-24T03:22:42.346Z",
+    "updated": "2017-05-24T03:22:59.623Z",
+    "author": null,
+    "creator": null,
+    "icon": "",
+    "description": null
+  }
+}, {
+  "model": "chartwerk.template",
+  "pk": 7,
+  "fields": {
+    "slug": "horizontal-bar-chart-paragraph-text",
+    "title": "horizontal-bar-chart-paragraph-text",
+    "data": {
+      "text": {
+        "chatter": "Twenty-three and one quarter people were asked, \"How was your day?\"",
+        "annotations": [],
+        "source": "SOURCE: Pew Research",
+        "legend": {
+          "single": {
+            "inside": false,
+            "position": {
+              "x": 10,
+              "y": 10
+            },
+            "align": "l",
+            "background": true,
+            "width": 250
+          },
+          "double": {
+            "inside": false,
+            "position": {
+              "x": 10,
+              "y": 10
+            },
+            "align": "l",
+            "background": true,
+            "width": 500
+          },
+          "title": "",
+          "active": false,
+          "keys": []
+        },
+        "author": "Jane Doe / DMN",
+        "headline": "Carpe Diem",
+        "title": "",
+        "footnote": ""
+      },
+      "template": {
+        "icon": null,
+        "tags": [],
+        "description": "This horizontal bar chart accomodates particularly long text labels. It's great for displaying survey data in which responses can be as long as whole sentences.",
+        "title": "Horizontal bar chart (paragraph text)"
+      },
+      "embed": {
+        "dimensions": {}
+      },
+      "scripts": {
+        "helper": "var werkHelper = {\n    parse: function(werk){\n        \n        werk.data = chartwerk.data.map(function(d){\n            return {\n                name: d[chartwerk.datamap.base],\n                value: d[chartwerk.datamap.value]\n            };\n        })\n        .sort(function(a, b){ return d3.descending(a.value, b.value); });\n    },\n    \n    dims: function(werk){\n        var s = chartwerk.ui.size;\n            w = werk.dims[s].width,\n            h = werk.dims[s].height,\n            margins = {\n                right: chartwerk.margins[s].right * w,\n                left: chartwerk.margins[s].left * w,\n                top: chartwerk.margins[s].top * h,\n                bottom: chartwerk.margins[s].bottom * h\n            },\n            div = {\n                width: w - margins.left - margins.right,\n                height: h - margins.top - margins.bottom\n            };\n        \n        werk.dims.margins = margins;\n        werk.dims.div = div;\n    },\n\n    scales: function(werk){\n        var div = werk.dims.div;\n        werk.scales = {\n            x: d3.scaleLinear()\n                .range([0, div.width]),\n        };\n    },\n    \n\n    valueDomain: function(werk){\n        var max = d3.max(werk.data, function(d) { \n                return d.value; \n            });\n        \n        if (chartwerk.axes.value.min && chartwerk.axes.value.max) {\n            werk.scales.x.domain(\n                [chartwerk.axes.value.min, chartwerk.axes.value.max]\n            );\n        } else if (chartwerk.axes.value.min) {\n            werk.scales.x.domain(\n                [chartwerk.axes.value.min, max ]\n            );\n        } else if (chartwerk.axes.value.max) {\n            werk.scales.x.domain(\n                [0, chartwerk.axes.value.max]\n            );\n        } else {\n            werk.scales.x.domain([0, max]);\n        }\n        \n        werk.scales.x.nice();\n    },\n\n\n    // Build dims, scales and axes.\n    build: function(werk){\n        this.parse(werk);\n        this.dims(werk);\n        this.scales(werk);\n        this.valueDomain(werk);\n        return werk;\n    },\n};",
+        "draw": "function draw(){\n\n    var initialProps = {\n        dims: {\n          single: { width: 260, height: 225 },\n          double: { width: 540, height: 250}\n        },\n    };\n    \n    // Returns object with properties and methods representing\n    // dimensions, scales, axes, etc.\n    var werk = werkHelper.build(initialProps);\n    \n    var comma = d3.format(\",\");\n    \n    var div = d3.select(\"#chart\")\n        .append(\"div\")\n        .style(\"margin\", \n            werk.dims.margins.top + \"px \" +\n            werk.dims.margins.right + \"px \" +\n            werk.dims.margins.bottom + \"px \" +\n            werk.dims.margins.left + \"px \"\n        );\n    \n    \n    var response = div.selectAll(\".response\")\n        .data(werk.data)\n      .enter().append(\"div\")\n        .attr(\"class\",\"response\");\n    \n    response.append(\"p\")\n    \t\t.text(function(d){ return d.name; });\n    \n    response.append(\"div\")\n        .attr(\"class\", \"bar\")\n        .style(\"background-color\", chartwerk.axes.color.range[0])\n        .style(\"width\", function(d){ return werk.scales.x(d.value) + 'px'; })\n      .append(\"div\")\n        .attr(\"class\",\"label\")\n      .append(\"p\")\n        .attr(\"class\", function(d){\n            return werk.scales.x(d.value) < 75 ?\n                'offset' : '';\n        })\n        .style(\"width\", function(d){\n            return werk.scales.x(d.value) < 75 ?\n                werk.dims.div.width - this.parentElement.parentElement.clientWidth + 'px' : '';\n        })\n        .style(\"margin-left\", function(d){\n            return werk.scales.x(d.value) < 75 ?\n                this.parentElement.parentElement.clientWidth + 'px' : '';\n        })\n        .text(function(d){\n            return chartwerk.axes.value.prefix + comma(String(d.value)) + chartwerk.axes.value.suffix;\n        });\n    \n\n}",
+        "styles": "#chartwerk {\n    width:560px;\n}\n#chartwerk div{\n    font-family:'Gotham A', 'Gotham B', arial, sans-serif; \n}\n#chartwerk.single{\n    width:270px;\n    float:left;\n    overflow:hidden;\n    margin:10px 30px 10px 0;\n}\n#chartwerk #headline { \n    font-weight:bold;\n    font-size:24px;\n}\n#chartwerk #chatter {\n    margin-top:5px;\n    font-size:14px;\n    line-height:19px;\n}\n#chartwerk #footnote,\n#chartwerk #source,\n#chartwerk #author {\n    font-size:11px;\n    color:grey;\n\n}\n#chartwerk #author {\n    text-align:right;\n}\n#chartwerk #chart{\n    background-color:white;\n}\n#chartwerk .response{\n    margin-top:10px;\n}\n#chartwerk .response p{\n    font: 13px/16px 'Gotham A', 'Gotham B', arial, sans-serif;\n}\n#chartwerk #chart .bar{\n    height:24px;\n    display:inline-block;\n    margin-top:2px;\n}\n#chartwerk #chart .bar .label{\n    width:100%;\n    text-align:right;\n}\n#chartwerk #chart .bar .label p{\n    padding-right:5px;\n    padding-top:4px;\n    font-weight:bold;\n    font-size:14px;\n    line-height:18px;\n    color:#fff;\n}\n#chartwerk #chart .bar .label p.offset{\n    text-align:left;\n    padding-left:3px;\n    color:#666;\n}",
+        "dependencies": {
+          "styles": ["https://cloud.typography.com/6922714/7642152/css/fonts.css", "https://interactives.dallasnews.com/common/fonts/gotham.css"],
+          "scripts": ["https://cdnjs.cloudflare.com/ajax/libs/d3/4.2.3/d3.min.js"]
+        },
+        "html": "<div id='chart-header'>\n\t<h2 id='headline'></h2>\n\t<div id='chatter'></div> \n</div> \n<div id='chart-ui'>\n\t<!--You can put any necessary buttons, etc., here.-->\n</div>\n<div id='chart-legend'></div>\n<div id='chart'></div> \n<div id='chart-footer'> \n\t<div id='footnote'></div> \n\t<div id='source'></div> \n\t<div id='author'></div> \n</div>"
+      },
+      "datamap": {
+        "value": "Percent",
+        "custom": {},
+        "ignore": [],
+        "scale": null,
+        "series": [],
+        "sort": ["Response", "Percent"],
+        "facet": null,
+        "annotations": [],
+        "base": "Response"
+      },
+      "axes": {
+        "color": {
+          "ignoreScale": false,
+          "domain": ["Percent"],
+          "byFacet": false,
+          "quantizeProps": {
+            "reverseColors": false,
+            "groups": 0,
+            "column": null
+          },
+          "scheme": "categorical.default",
+          "quantize": false,
+          "range": ["#329CEB"]
+        },
+        "value": {
+          "prefix": "",
+          "suffix": "%",
+          "min": null,
+          "shadedRegions": [],
+          "label": "",
+          "max": null,
+          "format": {
+            "single": {
+              "customTicks": [],
+              "ticks": 7
+            },
+            "double": {
+              "customTicks": [],
+              "ticks": 7
+            }
+          }
+        },
+        "scale": {
+          "prefix": "",
+          "suffix": ""
+        },
+        "base": {
+          "prefix": "",
+          "type": "categorical",
+          "suffix": "",
+          "min": null,
+          "shadedRegions": [],
+          "label": "",
+          "max": null,
+          "dateFormat": null,
+          "format": {
+            "single": {
+              "customTicks": [],
+              "dateString": "Y",
+              "ticks": 7,
+              "frequency": 2
+            },
+            "double": {
+              "customTicks": [],
+              "dateString": "Y",
+              "ticks": 7,
+              "frequency": 1
+            }
+          }
+        }
+      },
+      "ui": {
+        "size": "single",
+        "rawData": "Response\tPercent\nIt was great!\t40\nI was bitten by a feral cat.\t25\nMy mother bought me ice cream, but it melted too quickly.\t15\nI wish I were taller.\t6\n",
+        "datamap": [{
+          "available": true,
+          "class": "base",
+          "alias": "Category"
+        }, {
+          "available": true,
+          "class": "value",
+          "alias": "Value"
+        }, {
+          "available": false,
+          "class": "scale",
+          "alias": "scale axis"
+        }, {
+          "available": false,
+          "class": "series",
+          "alias": "data series"
+        }, {
+          "available": false,
+          "class": "facet",
+          "alias": "faceting column"
+        }, {
+          "available": false,
+          "class": "ignore",
+          "alias": "ignored column"
+        }]
+      },
+      "margins": {
+        "single": {
+          "left": 0,
+          "top": 0.03,
+          "right": 0,
+          "bottom": 0.040000000000000036
+        },
+        "double": {
+          "left": 0,
+          "top": 0.03,
+          "right": 0,
+          "bottom": 0.040000000000000036
+        }
+      },
+      "data": [{
+        "Response": "It was great!",
+        "Percent": 40
+      }, {
+        "Response": "I was bitten by a feral cat.",
+        "Percent": 25
+      }, {
+        "Response": "My mother bought me ice cream, but it melted too quickly.",
+        "Percent": 15
+      }, {
+        "Response": "I wish I were taller.",
+        "Percent": 6
+      }]
+    },
+    "created": "2017-05-25T01:25:10.857Z",
+    "updated": "2017-05-25T01:25:10.861Z",
+    "author": null,
+    "creator": null,
+    "icon": "",
+    "description": null
+  }
+}, {
+  "model": "chartwerk.template",
+  "pk": 8,
+  "fields": {
+    "slug": "vertical-bar-chart",
+    "title": "vertical-bar-chart",
+    "data": {
+      "text": {
+        "chatter": "Some states even have more letters in their names and abbreviations than others do.",
+        "annotations": [],
+        "source": "SOURCE: Pew Research",
+        "legend": {
+          "single": {
+            "inside": false,
+            "position": {
+              "x": 10,
+              "y": 10
+            },
+            "align": "l",
+            "background": true,
+            "width": 250
+          },
+          "double": {
+            "inside": false,
+            "position": {
+              "x": 10,
+              "y": 10
+            },
+            "align": "l",
+            "background": true,
+            "width": 500
+          },
+          "title": "",
+          "active": true,
+          "keys": [{
+            "text": "Abbreviation",
+            "color": "#E34E36"
+          }, {
+            "text": "Full name",
+            "color": "#329CEB"
+          }]
+        },
+        "author": "Jane Doe / DMN",
+        "headline": "States have names",
+        "title": "",
+        "footnote": ""
+      },
+      "template": {
+        "icon": null,
+        "tags": [],
+        "description": "Use vertical bar charts when you want to show comparisons of quantity. Examples include population by city, touchdowns by player or sales by vehicle model.\n\nAs a general rule, vertical bar charts should not be used to show trends over time, for example, how many homes are purchased each year. Use a line chart instead.\n\nYour data should contain:\n    * A column with categorical labels (like \u201cDallas\u201d, \u201cPhiladelphia\u201d, \u201cLos Angeles\u201d, etc.) that will serve as the categories for every bar or bar group.\n    * A column (or multiple columns) with numeric values that will determine the height of each bar.\n\n*Note:* Each category may contain more than one bar -- for example, you can plot major Texas cities (as categories) and show separate bars for the number of barbecue restaurants and the number of steakhouses in each city.",
+        "title": "Vertical bar chart"
+      },
+      "embed": {
+        "dimensions": {}
+      },
+      "scripts": {
+        "helper": "var werkHelper = {\n    parse: function(werk){\n        if (chartwerk.datamap.base === null) {\n            // If the chart doesn't have a base axis, raise an error.\n        } else {\n            // Otherwise, parse the data as passed.\n            werk.data = chartwerk.axes.color.domain.map(function(category){\n                return {\n                    name: category,\n                    values: chartwerk.data.map(function(d){\n                        return { x: d[chartwerk.datamap.base], y: d[category] };\n                    })\n                    .sort(function(a, b){ return d3.ascending(a.x, b.x); })\n                };\n            });\n        }\n    },\n    \n    dims: function(werk){\n        var s = chartwerk.ui.size;\n            w = werk.dims[s].width,\n            h = werk.dims[s].height,\n\n            margins = {\n                right: chartwerk.margins[s].right * w,\n                left: chartwerk.margins[s].left * w,\n                top: chartwerk.margins[s].top * h,\n                bottom: chartwerk.margins[s].bottom * h\n            },\n            svg = {\n                width: w - margins.left - margins.right,\n                height: h - margins.top - margins.bottom\n            };\n\n        werk.dims.margins = margins;\n        werk.dims.svg = svg;\n    },\n\n    scales: function(werk){\n        var svg = werk.dims.svg;\n\n        werk.scales = {\n            x0: d3.scaleBand()\n                    .rangeRound([0, svg.width]),\n            x1: d3.scaleBand()\n                    .padding(0.05),\n            y: d3.scaleLinear()\n                    .rangeRound([svg.height, 0]),\n            color: chartwerk.axes.color.range.length > 1 ? (\n                d3.scaleOrdinal()\n                  .domain(chartwerk.axes.color.domain)\n                  .range(chartwerk.axes.color.range)\n            ) : (\n                function(d) { return chartwerk.axes.color.range[0]; }\n            ),\n        };\n    },\n\n    baseDomain:  function(werk) {\n        var keys = chartwerk.axes.color.domain.sort();\n\n        werk.scales.x0.domain(\n            chartwerk.data.map(\n                function(dataPoint) { return dataPoint[chartwerk.datamap.base]; }\n            ).sort()\n        );\n        werk.scales.x1.domain(keys).rangeRound([0, werk.scales.x0.bandwidth()]);\n    },\n\n    valueDomain: function(werk) {\n        var keys = chartwerk.axes.color.domain.sort();\n\n        var useDefaultMin = (\n            (chartwerk.axes.value.min !== null) &&\n            (!isNaN(chartwerk.axes.value.min))\n        );\n\n        var dataMin = (useDefaultMin) ? (chartwerk.axes.value.min) : (\n            d3.min(chartwerk.data, function(d) {\n                return d3.min(keys, function(key) { return d[key]; });\n            })\n        );\n\n        if ((!useDefaultMin) && (dataMin > 0)) { dataMin = 0; }\n\n        var useDefaultMax = (\n            (chartwerk.axes.value.max !== null) &&\n            (!isNaN(chartwerk.axes.value.max))\n        );\n\n        var dataMax = (useDefaultMax) ? (chartwerk.axes.value.max) : (\n            d3.max(chartwerk.data, function(d) {\n                return d3.max(keys, function(key) { return d[key]; });\n            })\n        );\n\n        var extents = {\n            min: dataMin,\n            max: dataMax\n        };\n\n        werk.scales.y.domain([extents.min, extents.max]).nice();\n    },\n\n    axes: function(werk) {\n        werk.axes = {\n            x: d3.axisBottom(werk.scales.x0)\n                    .tickSizeInner(6)\n                    .tickSizeOuter(0)\n                    .tickPadding(3),\n\n            y: d3.axisLeft(werk.scales.y)\n                    .tickSizeInner(-werk.dims.svg.width)\n                    .tickSizeOuter(0)\n                    .tickPadding(7)\n                    .tickFormat( function(d){ \n                        var formatter = werk.scales.y.tickFormat();\n                        if (d >= 0) {\n                            return formatter(d) === '0' ? '0' : (\n                                chartwerk.axes.value.prefix +\n                                formatter(d) +\n                                chartwerk.axes.value.suffix\n                            );\n                        } else {\n                            return (\n                                '-' +\n                                chartwerk.axes.value.prefix +\n                                formatter(Math.abs(d)) +\n                                chartwerk.axes.value.suffix\n                            );\n                        }\n                    }),\n        };\n    },\n\n    valueTicks: function(werk){\n        var s = chartwerk.ui.size;\n\n        if (chartwerk.axes.value.format[s].customTicks.length > 0) { \n            werk.axes.y.tickValues(\n                chartwerk.axes.value.format[s].customTicks\n            );\n        } else {\n            hasTickConfig = (\n                chartwerk.axes.value.format[s].ticks !== null\n            ) && (\n                !isNaN(chartwerk.axes.value.format[s].ticks)\n            );\n\n            if (hasTickConfig) {\n                werk.axes.y.ticks(\n                    chartwerk.axes.value.format[s].ticks\n                );\n            }\n        }\n    },\n\n    highlightZero: function(werk) {\n        var keys = chartwerk.axes.color.domain.sort();\n\n        var dataMin = (\n            (chartwerk.axes.value.min !== null) &&\n            (!isNaN(chartwerk.axes.value.min))\n        ) ? (\n            chartwerk.axes.value.min\n        ) : (\n            d3.min(chartwerk.data, function(d) {\n                return d3.min(keys, function(key) { return d[key]; });\n            })\n        );\n\n        werk.highlightZeroLine = (dataMin < 0);\n    },\n\n    // Build dims, scales and axes.\n    build: function(werk){\n        this.parse(werk);\n        this.dims(werk);\n        this.scales(werk);\n        this.baseDomain(werk);\n        this.valueDomain(werk);\n        this.axes(werk);\n        this.valueTicks(werk);\n        this.highlightZero(werk);\n        return werk;\n    },\n};",
+        "draw": "function draw() {\n\n    var initialProps = {\n        dims: {\n          single: { width: 260, height: 225 },\n          double: { width: 540, height: 250}\n        },\n    };\n    \n    // Returns object with properties and methods representing\n    // dimensions, scales, axes, etc.\n    var werk = werkHelper.build(initialProps);\n\n    var hasYAxisLabel = chartwerk.axes.value.label !== '';\n    var yAxisLabelHeight = 20;\n\n    var totalSvgHeight = hasYAxisLabel ? (\n        werk.dims.svg.height + yAxisLabelHeight\n    ) : (\n        werk.dims.svg.height\n    );\n\n    var svg = d3.select('#chart').append('svg')\n            .style('background-color', 'transparent')\n            .attr(\n                'width',\n                (\n                    werk.dims.margins.left +\n                    werk.dims.svg.width +\n                    werk.dims.margins.right\n                )\n            )\n            .attr(\n                'height',\n                (\n                    werk.dims.margins.top +\n                    totalSvgHeight +\n                    werk.dims.margins.bottom\n                )\n            );\n\n    var chartTop = hasYAxisLabel ? werk.dims.margins.top + yAxisLabelHeight : werk.dims.margins.top;\n\n    var g = svg.append('g')\n        .attr(\n            'transform',\n            'translate(' +\n                werk.dims.margins.left + ',' +\n                chartTop +\n            ')'\n        );\n\n    var xAxis = g.append('g')\n        .attr('class', 'x axis')\n        .attr('transform', 'translate(0,' + werk.dims.svg.height + ')')\n        .call(werk.axes.x);\n\n    var yAxis = g.append('g')\n            .attr('class', 'y axis')\n            .call(werk.axes.y);\n\n    if (chartwerk.ui.size === 'double') {\n        yAxis.attr('transform', 'translate(0,-1)');\n    }\n\n    if (hasYAxisLabel) {\n        yAxis.append('text')\n            .attr('class', 'label')\n            .attr('y', -werk.dims.margins.top + 15  - yAxisLabelHeight)\n            .attr('x', -werk.dims.margins.left)\n            .style('text-anchor', 'start')\n            .text(chartwerk.axes.value.label);\n    }\n\n    g.append('g')\n        .selectAll('g')\n        .data(chartwerk.data)\n        .enter().append('g')\n            .attr('class', function(d) {\n                return d[chartwerk.datamap.base].toLowerCase() + '-group';\n            })\n            .attr(\n                'transform',\n                function(d) {\n                    return (\n                        'translate(' +\n                        werk.scales.x0(d[chartwerk.datamap.base]) +\n                        ',0)'\n                    );\n                }\n            )\n        .selectAll('rect')\n        .data(\n            function(d) {\n                var keys = chartwerk.axes.color.domain.sort();\n\n                return keys.map(function(key) { return {key: key, value: d[key]}; });\n            }\n        )\n        .enter().append('rect')\n            .attr('x', function(d) { return werk.scales.x1(d.key); })\n            .attr('y', function(d) {\n                // \n                return (d.value >= 0) ? (werk.scales.y(d.value)) : (werk.scales.y(0));\n            })\n            .attr('width', werk.scales.x1.bandwidth())\n            .attr('height', function(d) {\n                return Math.abs(werk.scales.y(d.value) - werk.scales.y(0));\n                // return (\n                //     d.value >= 0\n                // ) ? (\n                //     werk.dims.svg.height - werk.scales.y(d.value)\n                // ) : (\n                //     werk.scales.\n                // );\n            })\n            .attr('fill', function(d) { return werk.scales.color(d.key); })\n            .attr('class', 'bar')\n            .style('pointer-events', 'fill')\n                .on('mouseout',  hideTooltip)\n                .on('mousemove', showTooltip);\n\n    if (werk.highlightZeroLine) {\n        g.append('line')\n            .attr('class', 'zero')\n            .attr('x1', 0)\n            .attr('x2', werk.dims.svg.width)\n            .attr('y1', werk.scales.y(0))\n            .attr('y2', werk.scales.y(0));\n    }\n\n    var tooltip = d3.select('#chart')\n      .append('div')\n        .attr('class', 'tooltip')\n        .style('position', 'absolute');\n\n    tooltip\n      .append('div')\n      .attr('class', 'value');\n\n    function showTooltip() {\n        var columnData = d3.select(this).datum();\n\n        var tooltipColor = werk.scales.color(columnData.key);\n\n        var comma = d3.format(',');\n\n        d3.select('.tooltip .value')\n          .style('color', tooltipColor)\n          .text(function(){\n              var v = chartwerk.axes.value;\n              return v.prefix + comma(columnData.value) + v.suffix;\n          });\n\n        var p = d3.mouse(this.parentElement.parentElement);\n\n        d3.select('.tooltip')\n            .style('opacity', 1)\n            .style('top', function(){\n                var s = chartwerk.ui.size;\n\n                var h = werk.dims[s].height;\n\n                var pos = p[1] > (h / 2) ? p[1] + 10 : p[1] + 20;\n\n                return pos.toString() + 'px';\n            })\n            .style(\"left\", function(){\n                // We position either left or right of the mouse point based\n                // on whether we're past the midpoint of the chart. This protects\n                // against tooltips overflowing embedded iframes.\n                var s = chartwerk.ui.size;\n\n                var w = werk.dims[s].width;\n\n                var tipW = parseInt(d3.select(\".tooltip\").style(\"width\"), 10);\n\n                var pos = p[0] > (w / 2) ? p[0] - (tipW - 20) : p[0] + 40;\n\n                return pos.toString() + \"px\";\n            });\n    }\n\n    function hideTooltip() {\n      d3.select(\".tooltip\").style(\"opacity\", 0);\n    }\n}",
+        "styles": "#chartwerk {\n    font-family: 'Gotham A', 'Gotham B', arial, sans-serif; \n    width: 560px;\n}\n#chartwerk.single {\n    float: left;\n    margin: 10px 30px 10px 0;\n    overflow: hidden;\n    width: 270px;\n}\n#chartwerk #headline { \n    font-size: 24px;\n    font-weight: bold;\n}\n#chartwerk #chatter {\n    font-size: 14px;\n    line-height: 19px;\n    margin-bottom: 5px;\n    margin-top: 5px;\n}\n#chartwerk #footnote,\n#chartwerk #source,\n#chartwerk #author {\n    color: grey;\n    font-size: 11px;\n}\n#chartwerk #author {\n    text-align: right;\n}\n#chartwerk #chart {\n    background-color: white;\n}\n#chartwerk #chart-legend .chart-legend-container .key-label {\n    font: 11px 'Gotham A', 'Gotham B', arial, sans-serif;\n}\n#chartwerk #chart-legend .chart-legend-container .key-color {\n    margin-right: 2px;\n}\n#chartwerk #chart-legend .chart-legend-container .key {\n    margin-right: 8px;\n}\n#chartwerk .annotation p {\n    font-family: 'Gotham A', 'Gotham B', arial, sans-serif;\n}\n#chartwerk #chart .tooltip {\n    background: rgba(255,255,255,.75);\n    font: 13px 'Gotham A', 'Gotham B', arial, sans-serif;\n    opacity: 0;\n    padding: 5px;\n    pointer-events: none;\n    width: auto;\n}\n#chartwerk #chart .tooltip .value {\n    font-weight: bold;\n}\n#chartwerk #chart path.line {\n    fill: none;\n    stroke-width: 2px;\n}\n.axis path,\n.axis line {\n  fill: none;\n  shape-rendering: crispEdges;\n  stroke: rgb(180,180,180);\n}\n.axis text {\n    fill: rgb(132,132,132);\n    font-family: 'Gotham A', 'Gotham B', 'Montserrat', arial, sans-serif;\n    font-size: 11px;\n}\n.y.axis line {\n    stroke-dasharray: 3px 3px;\n}\n.y.axis path {\n    display:none;\n}\n.y.axis .label {\n    font-family: 'Gotham A', 'Gotham B', 'Montserrat', arial, sans-serif;\n    font-weight: normal;\n}\nrect.shaded-area{\n    fill: #DDDDDD;\n}\nline.zero {\n    stroke: #000000;\n    stroke-width: 1px;\n}",
+        "dependencies": {
+          "styles": ["https://cloud.typography.com/6922714/7642152/css/fonts.css", "https://interactives.dallasnews.com/common/fonts/gotham.css"],
+          "scripts": ["https://cdnjs.cloudflare.com/ajax/libs/d3/4.2.3/d3.min.js"]
+        },
+        "html": "<div id='chart-header'>\n\t<h2 id='headline'></h2>\n\t<div id='chatter'></div> \n</div> \n<div id='chart-ui'>\n\t<!--You can put any necessary buttons, etc., here.-->\n</div>\n<div id='chart-legend'></div>\n<div id='chart'></div> \n<div id='chart-footer'> \n\t<div id='footnote'></div> \n\t<div id='source'></div> \n\t<div id='author'></div> \n</div>"
+      },
+      "datamap": {
+        "value": null,
+        "custom": {},
+        "ignore": [],
+        "scale": null,
+        "series": ["Letter count", "Abbreviated"],
+        "sort": ["State", "Letter count", "Abbreviated"],
+        "facet": null,
+        "base": "State"
+      },
+      "axes": {
+        "color": {
+          "ignoreScale": false,
+          "domain": ["Abbreviated", "Letter count"],
+          "byFacet": false,
+          "quantizeProps": {
+            "reverseColors": false,
+            "groups": 0,
+            "column": null
+          },
+          "scheme": "categorical.default",
+          "quantize": false,
+          "range": ["#E34E36", "#329CEB"]
+        },
+        "value": {
+          "prefix": "",
+          "suffix": "",
+          "min": 0,
+          "shadedRegions": [],
+          "label": "Letter counts",
+          "max": 10,
+          "format": {
+            "single": {
+              "customTicks": [],
+              "ticks": 7
+            },
+            "double": {
+              "customTicks": [],
+              "ticks": 7
+            }
+          }
+        },
+        "scale": {
+          "prefix": "",
+          "suffix": ""
+        },
+        "base": {
+          "prefix": "",
+          "type": "categorical",
+          "suffix": "",
+          "min": null,
+          "shadedRegions": [],
+          "label": "",
+          "max": null,
+          "dateFormat": null,
+          "format": {
+            "single": {
+              "customTicks": [],
+              "dateString": "Y",
+              "ticks": 7,
+              "frequency": 2
+            },
+            "double": {
+              "customTicks": [],
+              "dateString": "Y",
+              "ticks": 7,
+              "frequency": 1
+            }
+          }
+        }
+      },
+      "ui": {
+        "size": "single",
+        "rawData": "State\tLetter count\tAbbreviated\nVirginia\t8\t3\nMissouri\t8\t3\nIowa\t4\t4\nTexas\t5\t5",
+        "datamap": [{
+          "available": true,
+          "class": "base",
+          "alias": "Category"
+        }, {
+          "available": true,
+          "class": "value",
+          "alias": "Single value"
+        }, {
+          "available": false,
+          "class": "scale",
+          "alias": "scale axis"
+        }, {
+          "available": true,
+          "class": "series",
+          "alias": "Grouped value"
+        }, {
+          "available": false,
+          "class": "facet",
+          "alias": "faceting column"
+        }, {
+          "available": true,
+          "class": "ignore",
+          "alias": "Ignored column"
+        }]
+      },
+      "margins": {
+        "single": {
+          "left": 0.11,
+          "top": 0.05,
+          "right": 0.020000000000000018,
+          "bottom": 0.10999999999999999
+        },
+        "double": {
+          "left": 0.06,
+          "top": 0.05,
+          "right": 0.020000000000000018,
+          "bottom": 0.07999999999999996
+        }
+      },
+      "data": [{
+        "Abbreviated": 3,
+        "State": "Virginia",
+        "Letter count": 8
+      }, {
+        "Abbreviated": 3,
+        "State": "Missouri",
+        "Letter count": 8
+      }, {
+        "Abbreviated": 4,
+        "State": "Iowa",
+        "Letter count": 4
+      }, {
+        "Abbreviated": 5,
+        "State": "Texas",
+        "Letter count": 5
+      }]
+    },
+    "created": "2017-05-25T01:26:04.017Z",
+    "updated": "2017-05-25T01:26:04.020Z",
+    "author": null,
+    "creator": null,
+    "icon": "",
+    "description": null
+  }
+}, {
+  "model": "chartwerk.template",
+  "pk": 9,
+  "fields": {
+    "slug": "unit-chart",
+    "title": "unit-chart",
+    "data": {
+      "text": {
+        "chatter": null,
+        "annotations": [],
+        "source": "Dallas Morning News analysis",
+        "legend": {
+          "single": {
+            "inside": false,
+            "position": {
+              "x": 10,
+              "y": 10
+            },
+            "align": "l",
+            "background": true,
+            "width": 250
+          },
+          "double": {
+            "inside": false,
+            "position": {
+              "x": 10,
+              "y": 10
+            },
+            "align": "l",
+            "background": true,
+            "width": 500
+          },
+          "title": "",
+          "active": true,
+          "keys": [{
+            "text": "A",
+            "color": "#E34E36"
+          }, {
+            "text": "J",
+            "color": "#329CEB"
+          }, {
+            "text": "Other",
+            "color": "#C9C9C9"
+          }]
+        },
+        "author": "John Doe",
+        "headline": "First letter for interactives team first names",
+        "title": "",
+        "footnote": null
+      },
+      "template": {
+        "icon": null,
+        "tags": [],
+        "description": null,
+        "title": "Unit chart"
+      },
+      "embed": {
+        "dimensions": {}
+      },
+      "scripts": {
+        "helper": "var werkHelper = {\n    dims: function(werk){\n        var s = chartwerk.ui.size;\n            w = werk.dims[s].width,\n            h = werk.dims[s].height,\n            margins = {\n                right: chartwerk.margins[s].right * w,\n                left: chartwerk.margins[s].left * w,\n                top: chartwerk.margins[s].top * h,\n                bottom: chartwerk.margins[s].bottom * h\n            },\n            svg = {\n                width: w - margins.left - margins.right,\n                height: h + 2 - margins.top - margins.bottom\n            };\n        \n        werk.dims.margins = margins;\n        werk.dims.svg = svg;\n    },\n    \n    scales: function(werk){\n        var svg = werk.dims.svg;\n        werk.scales = {\n            color: chartwerk.axes.color.quantize ? \n                d3.scaleQuantize() : d3.scaleOrdinal(),\n        };\n        \n        werk.scales.color\n            .domain(chartwerk.axes.color.domain)\n            .range(chartwerk.axes.color.range);\n    },\n\n    // Build dims, scales and axes.\n    build: function(werk){\n        this.dims(werk);\n        this.scales(werk);\n        return werk;\n    },\n};",
+        "draw": "function draw(){\n\n    var size = chartwerk.ui.size;\n\n    var VALUE_KEY = chartwerk.datamap.value;\n    var UNIT_SPACING = 4;\n    var UNITS_PER_ROW = size === 'double' ? 18 : 12;\n    var CHART_WIDTH = size === 'double' ? 580 : 270;\n    \n    var unitSize = ((CHART_WIDTH) / UNITS_PER_ROW) - UNIT_SPACING;\n    var totalUnits = chartwerk.data.reduce(function(m, d) {\n        return m + d[VALUE_KEY];\n    }, 0);\n    \n    var chartHeight = Math.ceil(totalUnits / UNITS_PER_ROW) * (UNIT_SPACING + unitSize);\n\n    var werk = werkHelper.build({\n        dims: {\n          single: {\n            width: CHART_WIDTH,\n            height: chartHeight\n          },\n          double: {\n            width: CHART_WIDTH,\n            height: chartHeight\n          }\n        }\n    });\n\n    var svg = d3.select('#chart')\n        .append('svg')\n        .attr('width', werk.dims.svg.width + werk.dims.margins.left + werk.dims.margins.right)\n        .attr('height', werk.dims.svg.height + werk.dims.margins.top + werk.dims.margins.bottom)\n      .append('g')\n        .attr('transform', 'translate(' + werk.dims.margins.left + ',' + werk.dims.margins.top + ')');\n\n    var i = 0;\n    var data = chartwerk.data.map(function(d) {\n      return d3.range(d[VALUE_KEY]).map(function() {\n        var e = JSON.parse(JSON.stringify(d));\n        e.idx = i++;\n        return e;\n      });\n    });\n    \n    var facets = svg.selectAll('.facet')\n      .data(data)\n      .enter().append('g')\n      .attr('class', 'facet');\n    \n    facets.selectAll('.unit')\n      .data(function(d) {\n        return d;\n      })\n      .enter()\n      .append('rect')\n      .attr('class', 'unit')\n      .attr('width', unitSize)\n      .attr('height', unitSize)\n      .attr('fill', function(d) {\n        return werk.scales.color(d[chartwerk.datamap.scale]);\n      })\n      .attr('x', function(d) {\n        return d.idx % UNITS_PER_ROW * (unitSize + UNIT_SPACING);\n      })\n      .attr('y', function(d) {\n        return Math.floor(d.idx / UNITS_PER_ROW) * (unitSize + UNIT_SPACING);\n      });\n\n  facets\n    .on('mouseover', function(d) {\n      d3.select(this).classed('highlight', true);\n      d3.select('.tooltip .title').text(d[0][chartwerk.datamap.scale]);\n      d3.select('.tooltip .value').text(d[0][VALUE_KEY]);\n    })\n    .on('mouseout', function(d) {\n      d3.select(this).classed('highlight', false);\n    });\n\n    var tooltip = d3.select(\"#chart\")\n      .append(\"div\")\n        .attr(\"class\",\"tooltip\")\n        .style(\"position\",\"absolute\");\n    tooltip\n      .append(\"div\")\n      .attr(\"class\",\"title\")\n      .text(chartwerk.datamap.scale);\n    tooltip\n      .append(\"div\")\n      .attr(\"class\",\"value\");\n}",
+        "styles": "\n#chartwerk {\n    font-family:'Gotham A', 'Gotham B', arial, sans-serif; \n    width:600px;\n}\n#chartwerk.single{\n    width:290px;\n    float:left;\n    overflow:hidden;\n    margin:10px 30px 10px 0;\n}\n#chartwerk #headline { \n    font-weight:bold;\n    font-size:24px;\n}\n#chartwerk #chatter {\n    margin-top:5px;\n}\n#chartwerk #footnote,\n#chartwerk #source,\n#chartwerk #author {\n    font-size:11px;\n    color:grey;\n\n}\n#chartwerk #author {\n    text-align:right;\n}\n#chartwerk #chart{\n    background-color:white;\n}\n#chartwerk #chart-legend \n.chart-legend-container .key-label{\n    font:11px 'Gotham A', 'Gotham B', arial, sans-serif;\n}\n#chartwerk #chart-legend \n.chart-legend-container .key-color{\n    margin-right:2px;\n}\n#chartwerk #chart-legend \n.chart-legend-container .key{\n    margin-right:8px;\n}\n#chartwerk .annotation p{\n    font-family:'Gotham A', 'Gotham B', arial, sans-serif;\n}\n#chartwerk #chart .tooltip{\n    font: 13px 'Gotham A', 'Gotham B', arial, sans-serif;\n    opacity:0;\n    pointer-events:none;\n    background:rgba(255,255,255,.75);\n    padding:5px;\n    width:auto;\n}\n#chartwerk #chart .tooltip .title{\n    font-weight: bold;\n    fill:grey;\n}\n.facet.highlight {\n    stroke: #000;\n}",
+        "dependencies": {
+          "styles": ["https://cloud.typography.com/6922714/7642152/css/fonts.css", "https://interactives.dallasnews.com/common/fonts/gotham.css"],
+          "scripts": ["https://cdnjs.cloudflare.com/ajax/libs/d3/4.2.3/d3.min.js"]
+        },
+        "html": "<div id='chart-header'>\n\t<h2 id='headline'></h2>\n\t<div id='chatter'></div> \n</div> \n<div id='chart-ui'>\n\t<!--You can put any necessary buttons, etc., here.-->\n</div>\n<div id='chart-legend'></div>\n<div id='chart'></div> \n<div id='chart-footer'> \n\t<div id='footnote'></div> \n\t<div id='source'></div> \n\t<div id='author'></div> \n</div>"
+      },
+      "datamap": {
+        "value": "Number",
+        "custom": {},
+        "ignore": [],
+        "scale": "County",
+        "series": [],
+        "sort": [],
+        "facet": null,
+        "annotations": [],
+        "base": null
+      },
+      "axes": {
+        "color": {
+          "ignoreScale": false,
+          "domain": ["A", "J", "Other"],
+          "byFacet": true,
+          "quantizeProps": {
+            "reverseColors": false,
+            "groups": 0,
+            "column": null
+          },
+          "scheme": "categorical.default",
+          "quantize": false,
+          "range": ["#E34E36", "#329CEB", "#C9C9C9"]
+        },
+        "value": {
+          "prefix": "$",
+          "suffix": "",
+          "min": null,
+          "shadedRegions": [],
+          "label": "Dollars",
+          "max": null,
+          "format": {
+            "single": {
+              "customTicks": [],
+              "ticks": 7
+            },
+            "double": {
+              "customTicks": [],
+              "ticks": 7
+            }
+          }
+        },
+        "scale": {
+          "prefix": "",
+          "suffix": ""
+        },
+        "base": {
+          "prefix": "",
+          "type": "categorical",
+          "suffix": "",
+          "min": null,
+          "shadedRegions": [],
+          "label": "",
+          "max": null,
+          "dateFormat": null,
+          "format": {
+            "single": {
+              "customTicks": [],
+              "dateString": "Y",
+              "ticks": 7,
+              "frequency": 2
+            },
+            "double": {
+              "customTicks": [],
+              "dateString": "Y",
+              "ticks": 7,
+              "frequency": 1
+            }
+          }
+        }
+      },
+      "ui": {
+        "size": "double",
+        "rawData": "County\tNumber\nA\t30\nJ\t20\nOther\t30",
+        "datamap": [{
+          "available": false,
+          "class": "base",
+          "alias": "base axis"
+        }, {
+          "available": true,
+          "class": "value",
+          "alias": "Value"
+        }, {
+          "available": true,
+          "class": "scale",
+          "alias": "Color group"
+        }, {
+          "available": false,
+          "class": "series",
+          "alias": "data series"
+        }, {
+          "available": false,
+          "class": "facet",
+          "alias": "faceting column"
+        }, {
+          "available": false,
+          "class": "ignore",
+          "alias": "ignored column"
+        }]
+      },
+      "margins": {
+        "single": {
+          "left": 0,
+          "top": 0,
+          "right": 0,
+          "bottom": 0
+        },
+        "double": {
+          "left": 0,
+          "top": 0,
+          "right": 0,
+          "bottom": 0
+        }
+      },
+      "data": [{
+        "County": "A",
+        "Number": 30
+      }, {
+        "County": "J",
+        "Number": 20
+      }, {
+        "County": "Other",
+        "Number": 30
+      }]
+    },
+    "created": "2017-05-25T01:26:43.204Z",
+    "updated": "2017-05-25T01:26:43.206Z",
+    "author": null,
+    "creator": null,
+    "icon": "",
+    "description": null
+  }
+}, {
+  "model": "chartwerk.template",
+  "pk": 10,
+  "fields": {
+    "slug": "data-table",
+    "title": "data-table",
+    "data": {
+      "text": {
+        "chatter": "These are some made up numbers about all these places.",
+        "annotations": [],
+        "source": "SOURCE: Wiki",
+        "legend": {
+          "single": {
+            "inside": false,
+            "position": {
+              "x": 10,
+              "y": 10
+            },
+            "align": "l",
+            "background": true,
+            "width": 250
+          },
+          "double": {
+            "inside": false,
+            "position": {
+              "x": 10,
+              "y": 10
+            },
+            "align": "l",
+            "background": true,
+            "width": 500
+          },
+          "title": "",
+          "active": false,
+          "keys": []
+        },
+        "author": "Jane Doe / DMN",
+        "headline": "A tale of twelve cities",
+        "title": "",
+        "footnote": ""
+      },
+      "template": {
+        "icon": null,
+        "tags": [],
+        "description": "Use this template to create a basic table.\n\nJust paste your table in; none of the usual chart configuration is required for this template.",
+        "title": "Data table"
+      },
+      "embed": {
+        "dimensions": {}
+      },
+      "scripts": {
+        "helper": "var werkHelper = {};",
+        "draw": "function draw(){\n\n    var keys = chartwerk.datamap.sort;\n    \n    var table = d3.select(\"#chart\")\n        .append(\"div\")\n        .attr(\"id\",\"table\")\n        .append(\"table\");\n    \n    var thead = table.append(\"thead\");\n    \n    keys.forEach(function(k){\n        thead.append(\"th\")\n            .attr(\"class\", \"sort\")\n            .attr(\"data-sort\", k)\n            .text(k);\n    });\n    \n    var tbody = table.append(\"tbody\")\n            .attr(\"class\", \"list\");\n    \n    chartwerk.data.forEach(function(d){\n        var tr = tbody.append(\"tr\");\n        keys.forEach(function(k){\n            tr.append(\"td\")\n                .attr(\"class\", \"td \"+ k)\n                .text(d[k]);\n        });\n    });\n    \n    var tableOptions = {\n      valueNames: keys\n    };\n\n    var tableList = new List('table', tableOptions);\n    \n    // List\n    \n    var list = d3.select(\"#chart\")\n        .append(\"div\")\n        .attr(\"id\",\"list\")\n        .attr(\"class\",\"hidden\");\n    \n    list.append(\"ul\")\n        .attr(\"class\", \"list\");\n    \n    paras = keys.map(function(k){\n        return '<p><span class=\"list-hed\">'+k+'</span> <span class=\"'+k+'\"></span></p>';\n    }).join('');\n    \n    var listOptions = {\n      valueNames: keys,\n      item: '<li>'+paras+'</li>'\n    };\n    \n    var listList = new List('list', listOptions, chartwerk.data);\n    \n    function switchStyle(){\n        if($(\"#chart\").width() < $(\"#table\")[0].scrollWidth){\n            $(\"#table\").addClass(\"hidden\");\n            $(\"#list\").removeClass(\"hidden\");\n        }\n    }\n    setTimeout(function(){\n        switchStyle();\n    }, 100);\n    \n\n}",
+        "styles": "#chartwerk {\n    width:560px;\n}\n#chartwerk div, #chartwerk p{\n    font-family:'Gotham A', 'Gotham B', arial, sans-serif;\n}\n#chartwerk.single{\n    width:270px;\n    float:left;\n    overflow:hidden;\n    margin:10px 30px 10px 0;\n}\n#chartwerk #headline { \n    font-weight:bold;\n    font-size:24px;\n}\n#chartwerk #chatter {\n    margin-top:5px;\n    font-size:14px;\n    line-height:19px;\n}\n#chartwerk #footnote,\n#chartwerk #source,\n#chartwerk #author {\n    font-size:11px;\n    color:grey;\n\n}\n#chartwerk #author {\n    text-align:right;\n}\n#chartwerk #chart{\n    background-color:white;\n}\n#chartwerk table{\n    margin:10px 0 20px;\n    overflow-x:visible;\n    text-align:left;\n    width:100%;\n}\n#chartwerk table th, #chartwerk table td{\n    padding:2px 10px 2px 5px;\n    \n}\n#chartwerk table th{\n    border-bottom:2px solid grey;\n    cursor:pointer;\n    vertical-align: bottom;\n}\n#chartwerk table th:hover{\n    background-color:lightgrey;\n}\n#chartwerk table tbody tr:first-child td{\n    padding-top:10px;\n}\n#chartwerk table tbody tr{\n    border-bottom:1px solid lightgrey;\n}\n#chartwerk table tr:hover{\n    background-color:#ccc !important;\n}\n#chartwerk #list{\n    margin:10px 0 20px;\n    max-height:300px;\n    overflow-y:scroll;\n}\n#chartwerk #list li{\n    border-bottom:1px solid lightgrey;\n    padding: 5px 0;\n}\n\n#chartwerk #list p{\n    text-align:left;\n    margin:1px 0;\n    line-height:12px;\n    padding:2px;\n    font-size:12px;\n}\n#chartwerk #list p span.list-hed{\n    font-size:10px;\n    color:grey;\n    display:inline-block;\n    width:25%;\n    word-wrap: normal;\n    line-height:12px;\n}\n::-webkit-scrollbar{\n  width: 6px;\n}\n\n::-webkit-scrollbar-track{\n  background: rgba(0, 0, 0, 0.1);\n  border-radius:5px;\n}\n\n::-webkit-scrollbar-thumb{\n  background: rgba(0, 0, 0, 0.4);\n  border-radius:5px;\n}\n.hidden{\n    display:none !important;\n}",
+        "dependencies": {
+          "styles": ["https://cloud.typography.com/6922714/7642152/css/fonts.css", "https://interactives.dallasnews.com/common/fonts/gotham.css"],
+          "scripts": ["https://cdnjs.cloudflare.com/ajax/libs/d3/4.2.3/d3.min.js", "https://cdnjs.cloudflare.com/ajax/libs/list.js/1.2.0/list.min.js"]
+        },
+        "html": "<div id='chart-header'>\n\t<h2 id='headline'></h2>\n\t<div id='chatter'></div> \n</div> \n<div id='chart-ui'>\n\t<!--You can put any necessary buttons, etc., here.-->\n</div>\n<div id='chart-legend'></div>\n<div id='chart'></div> \n<div id='chart-footer'> \n\t<div id='footnote'></div> \n\t<div id='source'></div> \n\t<div id='author'></div> \n</div>"
+      },
+      "datamap": {
+        "value": null,
+        "custom": {},
+        "ignore": [],
+        "scale": null,
+        "series": [],
+        "sort": ["City", "Country", "Numbers", "More", "Another"],
+        "facet": null,
+        "annotations": [],
+        "base": null
+      },
+      "axes": {
+        "color": {
+          "ignoreScale": false,
+          "domain": [],
+          "byFacet": false,
+          "quantizeProps": {
+            "reverseColors": false,
+            "groups": 0,
+            "column": null
+          },
+          "scheme": "categorical.default",
+          "quantize": false,
+          "range": []
+        },
+        "value": {
+          "prefix": "",
+          "suffix": "%",
+          "min": null,
+          "shadedRegions": [],
+          "label": "",
+          "max": null,
+          "format": {
+            "single": {
+              "customTicks": [],
+              "ticks": 7
+            },
+            "double": {
+              "customTicks": [],
+              "ticks": 7
+            }
+          }
+        },
+        "scale": {
+          "prefix": "",
+          "suffix": ""
+        },
+        "base": {
+          "prefix": "",
+          "type": "categorical",
+          "suffix": "",
+          "min": null,
+          "shadedRegions": [],
+          "label": "",
+          "max": null,
+          "dateFormat": null,
+          "format": {
+            "single": {
+              "customTicks": [],
+              "dateString": "Y",
+              "ticks": 7,
+              "frequency": 2
+            },
+            "double": {
+              "customTicks": [],
+              "dateString": "Y",
+              "ticks": 7,
+              "frequency": 1
+            }
+          }
+        }
+      },
+      "ui": {
+        "size": "double",
+        "rawData": "City\tCountry\tNumbers\tMore\tAnother\nAsheville\tUS\t12\t14\t234\nBoston\tUS\t11\t11.12\t334\nBelfast\tUK\t9\t7\t124\nLos Angeles\tUS\t7\t3.45\t151\nNew York\tUS\t7\t6.77\t323\nDallas\tUS\t6\t4\t272\nDenver\tUS\t2\t8\t234\nLondon\tUK\t-3\t10.22\t334\nKansas City\tUS\t-4\t16.66\t124\nBerlin\tDE\t-7\t13\t123\nLisbon\tPT\t-10\t41.11\t412\nHelsinki\tFI\t-12\t14.3\t311\n",
+        "datamap": [{
+          "available": true,
+          "class": "base",
+          "alias": "base axis"
+        }, {
+          "available": true,
+          "class": "value",
+          "alias": "value axis"
+        }, {
+          "available": true,
+          "class": "scale",
+          "alias": "scale axis"
+        }, {
+          "available": true,
+          "class": "series",
+          "alias": "data series"
+        }, {
+          "available": true,
+          "class": "facet",
+          "alias": "faceting column"
+        }, {
+          "available": true,
+          "class": "ignore",
+          "alias": "ignored column"
+        }]
+      },
+      "margins": {
+        "single": {
+          "left": 0,
+          "top": 0.03,
+          "right": 0,
+          "bottom": 0.040000000000000036
+        },
+        "double": {
+          "left": 0,
+          "top": 0.03,
+          "right": 0,
+          "bottom": 0.040000000000000036
+        }
+      },
+      "data": [{
+        "Country": "US",
+        "Numbers": 12,
+        "Another": 234,
+        "More": 14,
+        "City": "Asheville"
+      }, {
+        "Country": "US",
+        "Numbers": 11,
+        "Another": 334,
+        "More": 11.12,
+        "City": "Boston"
+      }, {
+        "Country": "UK",
+        "Numbers": 9,
+        "Another": 124,
+        "More": 7,
+        "City": "Belfast"
+      }, {
+        "Country": "US",
+        "Numbers": 7,
+        "Another": 151,
+        "More": 3.45,
+        "City": "Los Angeles"
+      }, {
+        "Country": "US",
+        "Numbers": 7,
+        "Another": 323,
+        "More": 6.77,
+        "City": "New York"
+      }, {
+        "Country": "US",
+        "Numbers": 6,
+        "Another": 272,
+        "More": 4,
+        "City": "Dallas"
+      }, {
+        "Country": "US",
+        "Numbers": 2,
+        "Another": 234,
+        "More": 8,
+        "City": "Denver"
+      }, {
+        "Country": "UK",
+        "Numbers": -3,
+        "Another": 334,
+        "More": 10.22,
+        "City": "London"
+      }, {
+        "Country": "US",
+        "Numbers": -4,
+        "Another": 124,
+        "More": 16.66,
+        "City": "Kansas City"
+      }, {
+        "Country": "DE",
+        "Numbers": -7,
+        "Another": 123,
+        "More": 13,
+        "City": "Berlin"
+      }, {
+        "Country": "PT",
+        "Numbers": -10,
+        "Another": 412,
+        "More": 41.11,
+        "City": "Lisbon"
+      }, {
+        "Country": "FI",
+        "Numbers": -12,
+        "Another": 311,
+        "More": 14.3,
+        "City": "Helsinki"
+      }]
+    },
+    "created": "2017-05-25T01:27:32.715Z",
+    "updated": "2017-05-25T01:27:32.718Z",
+    "author": null,
+    "creator": null,
+    "icon": "",
+    "description": null
+  }
+}, {
+  "model": "chartwerk.template",
+  "pk": 11,
+  "fields": {
+    "slug": "horizontal-bar-chart",
+    "title": "horizontal-bar-chart",
+    "data": {
+      "text": {
+        "chatter": "Some states even have more letters in their names than some others.",
+        "annotations": [],
+        "source": "SOURCE: Pew Research",
+        "legend": {
+          "single": {
+            "inside": false,
+            "position": {
+              "x": 10,
+              "y": 10
+            },
+            "align": "l",
+            "background": true,
+            "width": 250
+          },
+          "double": {
+            "inside": false,
+            "position": {
+              "x": 10,
+              "y": 10
+            },
+            "align": "l",
+            "background": true,
+            "width": 500
+          },
+          "title": "",
+          "active": false,
+          "keys": []
+        },
+        "author": "Jane Doe / DMN",
+        "headline": "States have names",
+        "title": "",
+        "footnote": ""
+      },
+      "template": {
+        "icon": null,
+        "tags": [],
+        "description": "Use horizontal bar charts when you want to show comparisons of quantity. Examples include population by city, touchdowns by player or sales by vehicle model.\n\nAs a general rule, horizontal bar charts should not be used to show trends over time, for example, how many homes are purchased each year. Use a line chart instead.\n\nYour data should contain two columns:\n\n* One with the categorical labels, like \"Dallas\", \"Philadelphia\", \"Los Angeles\", etc.\n* And another that contains the numeric values that will determine the width of the bars. ",
+        "title": "Horizontal bar chart"
+      },
+      "embed": {
+        "dimensions": {}
+      },
+      "scripts": {
+        "helper": "var werkHelper = {\n    parse: function(werk){\n        \n        werk.data = chartwerk.data.map(function(d){\n            return {\n                name: d[chartwerk.datamap.base].toString(),\n                value: d[chartwerk.datamap.value]\n            };\n        });\n    },\n    \n    dims: function(werk){\n        var s = chartwerk.ui.size;\n            w = werk.dims[s].width,\n            h = werk.dims[s].height,\n            // Add a little extra left margin to accomondate labels\n            maxLen = d3.max(werk.data, function(d){ return d.name.length; })\n            margins = {\n                right: chartwerk.margins[s].right * w,\n                left: chartwerk.margins[s].left * w + (maxLen * 4),\n                top: chartwerk.margins[s].top * h,\n                bottom: chartwerk.margins[s].bottom * h\n            },\n            div = {\n                width: w - margins.left - margins.right,\n                height: h - margins.top - margins.bottom\n            };\n            console.log(maxLen);\n        \n        \n        werk.dims.margins = margins;\n        werk.dims.div = div;\n    },\n\n    scales: function(werk){\n        var div = werk.dims.div;\n        werk.scales = {\n            x: d3.scaleLinear()\n                .range([0, div.width]),\n        };\n    },\n    \n\n    valueDomain: function(werk){\n        var max = d3.max(werk.data, function(d) { \n                return d.value; \n            });\n        \n        if (chartwerk.axes.value.min && chartwerk.axes.value.max) {\n            werk.scales.x.domain(\n                [chartwerk.axes.value.min, chartwerk.axes.value.max]\n            );\n        } else if (chartwerk.axes.value.min) {\n            werk.scales.x.domain(\n                [chartwerk.axes.value.min, max ]\n            );\n        } else if (chartwerk.axes.value.max) {\n            werk.scales.x.domain(\n                [0, chartwerk.axes.value.max]\n            );\n        } else {\n            werk.scales.x.domain([0, max]);\n        }\n        \n        werk.scales.x.nice();\n    },\n\n\n    // Build dims, scales and axes.\n    build: function(werk){\n        this.parse(werk);\n        this.dims(werk);\n        this.scales(werk);\n        this.valueDomain(werk);\n        return werk;\n    },\n};",
+        "draw": "function draw(){\n\n    var initialProps = {\n        dims: {\n          single: { width: 260, height: 225 },\n          double: { width: 540, height: 250}\n        },\n    };\n    \n    // Returns object with properties and methods representing\n    // dimensions, scales, axes, etc.\n    var werk = werkHelper.build(initialProps);\n    \n    var comma = d3.format(\",\");\n    \n    var div = d3.select(\"#chart\")\n        .append(\"div\")\n        .style(\"margin\", \n            werk.dims.margins.top + \"px \" +\n            werk.dims.margins.right + \"px \" +\n            werk.dims.margins.bottom + \"px \" +\n            werk.dims.margins.left + \"px \"\n        );\n    \n    \n    var response = div.selectAll(\".response\")\n        .data(werk.data)\n      .enter().append(\"div\")\n        .attr(\"class\",\"response\");\n    \n    var bar = response.append(\"div\")\n        .attr(\"class\", \"bar\")\n        .style(\"background-color\", chartwerk.axes.color.range[0])\n        .style(\"width\", function(d){ return werk.scales.x(d.value) + 'px'; });\n    \n    bar.append(\"div\")\n        .attr(\"class\",\"name label\")\n      .append(\"p\")\n        .text(function(d){ return d.name;});\n        \n    bar.append(\"div\")\n        .attr(\"class\",\"value label\")\n      .append(\"p\")\n        .attr(\"class\", function(d){\n            return werk.scales.x(d.value) < 75 ?\n                'offset' : '';\n        })\n        .style(\"width\", function(d){\n            return werk.scales.x(d.value) < 75 ?\n                werk.dims.div.width - this.parentElement.parentElement.clientWidth + 'px' : '';\n        })\n        .style(\"margin-left\", function(d){\n            return werk.scales.x(d.value) < 75 ?\n                this.parentElement.parentElement.clientWidth + 'px' : '';\n        })\n        .text(function(d){\n            return chartwerk.axes.value.prefix + comma(String(d.value)) + chartwerk.axes.value.suffix;\n        });\n    \n\n}",
+        "styles": "#chartwerk {\n    width:560px;\n}\n#chartwerk div{\n    font-family:'Gotham A', 'Gotham B', arial, sans-serif; \n}\n#chartwerk.single{\n    width:270px;\n    float:left;\n    overflow:hidden;\n    margin:10px 30px 10px 0;\n}\n#chartwerk #headline { \n    font-weight:bold;\n    font-size:24px;\n}\n#chartwerk #chatter {\n    margin-top:5px;\n    font-size:14px;\n    line-height:19px;\n}\n#chartwerk #footnote,\n#chartwerk #source,\n#chartwerk #author {\n    font-size:11px;\n    color:grey;\n\n}\n#chartwerk #author {\n    text-align:right;\n}\n#chartwerk #chart{\n    background-color:white;\n}\n#chartwerk .response{\n    margin-top:5px;\n}\n#chartwerk .response p{\n    font: 13px/16px 'Gotham A', 'Gotham B', arial, sans-serif;\n}\n#chartwerk #chart .bar{\n    height:24px;\n    display:inline-block;\n}\n#chartwerk #chart .bar .label{\n    width:100%;\n    text-align:right;\n}\n#chartwerk #chart .bar .name.label{\n    width:100%;\n    text-align:right;\n    padding:5px 5px 0 0;\n    margin-left:-100%;\n    position:absolute;\n    color:#666;\n}\n#chartwerk #chart .bar .value.label p{\n    padding-right:5px;\n    padding-top:4px;\n    font-weight:bold;\n    font-size:14px;\n    line-height:18px;\n    color:#fff;\n}\n#chartwerk #chart .bar .value.label p.offset{\n    text-align:left;\n    padding-left:3px;\n    color:#666;\n}",
+        "dependencies": {
+          "styles": ["https://cloud.typography.com/6922714/7642152/css/fonts.css", "https://interactives.dallasnews.com/common/fonts/gotham.css"],
+          "scripts": ["https://cdnjs.cloudflare.com/ajax/libs/d3/4.2.3/d3.min.js"]
+        },
+        "html": "<div id='chart-header'>\n\t<h2 id='headline'></h2>\n\t<div id='chatter'></div> \n</div> \n<div id='chart-ui'>\n\t<!--You can put any necessary buttons, etc., here.-->\n</div>\n<div id='chart-legend'></div>\n<div id='chart'></div> \n<div id='chart-footer'> \n\t<div id='footnote'></div> \n\t<div id='source'></div> \n\t<div id='author'></div> \n</div>"
+      },
+      "datamap": {
+        "value": "Numbers",
+        "custom": {},
+        "ignore": [],
+        "scale": null,
+        "series": [],
+        "sort": [],
+        "facet": null,
+        "annotations": [],
+        "base": "State"
+      },
+      "axes": {
+        "color": {
+          "ignoreScale": false,
+          "domain": ["Numbers"],
+          "byFacet": false,
+          "quantizeProps": {
+            "reverseColors": false,
+            "groups": 0,
+            "column": null
+          },
+          "scheme": "categorical.default",
+          "quantize": false,
+          "range": ["#329CEB"]
+        },
+        "value": {
+          "prefix": "",
+          "suffix": "",
+          "min": null,
+          "shadedRegions": [],
+          "label": "",
+          "max": null,
+          "format": {
+            "single": {
+              "customTicks": [],
+              "ticks": 7
+            },
+            "double": {
+              "customTicks": [],
+              "ticks": 7
+            }
+          }
+        },
+        "scale": {
+          "prefix": "",
+          "suffix": ""
+        },
+        "base": {
+          "prefix": "",
+          "type": "categorical",
+          "suffix": "",
+          "min": null,
+          "shadedRegions": [],
+          "label": "",
+          "max": null,
+          "dateFormat": null,
+          "format": {
+            "single": {
+              "customTicks": [],
+              "dateString": "Y",
+              "ticks": 7,
+              "frequency": 2
+            },
+            "double": {
+              "customTicks": [],
+              "dateString": "Y",
+              "ticks": 7,
+              "frequency": 1
+            }
+          }
+        }
+      },
+      "ui": {
+        "size": "single",
+        "rawData": "State\tNumbers\nKentucky\t8\nMassachusetts\t13\nArizona\t7\nMissouri\t8\nCalifornia\t10\nNew York\t8\nTexas\t5\n",
+        "datamap": [{
+          "available": true,
+          "class": "base",
+          "alias": "Category"
+        }, {
+          "available": true,
+          "class": "value",
+          "alias": "Value"
+        }, {
+          "available": false,
+          "class": "scale",
+          "alias": "scale axis"
+        }, {
+          "available": false,
+          "class": "series",
+          "alias": "data series"
+        }, {
+          "available": false,
+          "class": "facet",
+          "alias": "faceting column"
+        }, {
+          "available": false,
+          "class": "ignore",
+          "alias": "ignored column"
+        }]
+      },
+      "margins": {
+        "single": {
+          "left": 0.19,
+          "top": 0.04,
+          "right": 0,
+          "bottom": 0.040000000000000036
+        },
+        "double": {
+          "left": 0.09,
+          "top": 0.04,
+          "right": 0,
+          "bottom": 0.040000000000000036
+        }
+      },
+      "data": [{
+        "State": "Kentucky",
+        "Numbers": 8
+      }, {
+        "State": "Massachusetts",
+        "Numbers": 13
+      }, {
+        "State": "Arizona",
+        "Numbers": 7
+      }, {
+        "State": "Missouri",
+        "Numbers": 8
+      }, {
+        "State": "California",
+        "Numbers": 10
+      }, {
+        "State": "New York",
+        "Numbers": 8
+      }, {
+        "State": "Texas",
+        "Numbers": 5
+      }]
+    },
+    "created": "2017-05-25T01:28:21.651Z",
+    "updated": "2017-05-25T01:28:21.655Z",
+    "author": null,
+    "creator": null,
+    "icon": "",
+    "description": null
+  }
+}]

--- a/chartwerk/serializers.py
+++ b/chartwerk/serializers.py
@@ -37,8 +37,12 @@ class TemplateSerializer(serializers.HyperlinkedModelSerializer):
     def create(self, validated_data):
         properties_data = validated_data.pop('template_properties')
         template = Template.objects.create(**validated_data)
-        for property in properties_data:
-            obj = TemplateProperty.objects.get(slug=property.get('slug'))
+        for property_ in properties_data:
+            try:
+                obj = TemplateProperty.objects.get(slug=property_.get('slug'))
+            except TemplateProperty.DoesNotExist:
+                continue
+
             obj.template.add(template)
         return template
 
@@ -51,9 +55,14 @@ class TemplateSerializer(serializers.HyperlinkedModelSerializer):
         # SYNC template tags
         tags_list = []
         # ADD new template tags
-        for property in properties_data:
-            slug = property.get('slug')
-            obj = TemplateProperty.objects.get(slug=slug)
+        for property_ in properties_data:
+            slug = property_.get('slug')
+
+            try:
+                obj = TemplateProperty.objects.get(slug=slug)
+            except TemplateProperty.DoesNotExist:
+                continue
+
             obj.template.add(instance)
             tags_list.append(slug)
         # REMOVE any template tags not in the new set


### PR DESCRIPTION
See #15

Also beautifies free template fixtures to ease hand-edits in the future and avoids using reserved word `property` where possible