### PR TITLE
Don't use env vars and don't modify settings

### DIFF
--- a/chartwerk/apps.py
+++ b/chartwerk/apps.py
@@ -4,6 +4,8 @@ import dj_database_url
 from django.apps import AppConfig
 from django.conf import settings
 
+from chartwerk.exceptions import ChartwerkConfigError
+
 
 class ChartwerkConfig(AppConfig):
     name = 'chartwerk'
@@ -17,127 +19,56 @@ class ChartwerkConfig(AppConfig):
 # REQUIRED SETTINGS #
 #####################
 
-class ChartwerkConfigError(Exception):
-    """Raised when required config is not present."""
-
-    pass
-
-
-try:
-    settings.CHARTWERK_DOMAIN = os.getenv(
-        'CHARTWERK_DOMAIN', settings.CHARTWERK_DOMAIN)
-except:
-    raise ChartwerkConfigError('You haven\'t set the CHARTWERK_DOMAIN \
-variable. Set it either in your project settings or as an \
-environment variable.')
-
-try:
-    settings.CHARTWERK_EMBED_SCRIPT = os.getenv(
-        'CHARTWERK_EMBED_SCRIPT', settings.CHARTWERK_EMBED_SCRIPT)
-except:
-    raise ChartwerkConfigError('You haven\'t set the CHARTWERK_EMBED_SCRIPT \
-variable. Set it either in your project settings or as \
-an environment variable.')
-
-try:
-    settings.CHARTWERK_AWS_BUCKET = os.getenv(
-        'CHARTWERK_AWS_BUCKET', settings.CHARTWERK_AWS_BUCKET)
-except:
-    raise ChartwerkConfigError('You haven\'t set the CHARTWERK_AWS_BUCKET \
-variable. Set it either in your project settings or as \
-an environment variable.')
-
-if not bool(os.getenv('AWS_ACCESS_KEY_ID', False)):
-    raise ChartwerkConfigError('You haven\'t set the AWS_ACCESS_KEY_ID \
-variable. Set it as an environment variable.')
-
-if not bool(os.getenv('AWS_SECRET_ACCESS_KEY', False)):
-    raise ChartwerkConfigError('You haven\'t set the AWS_SECRET_ACCESS_KEY \
-variable. Set it as an environment variable.')
-
-########################
-# SETTINGS W/ DEFAULTS #
-########################
-
-settings.CHARTWERK_OEMBED = os.getenv(
-    'CHARTWERK_OEMBED', getattr(settings, 'CHARTWERK_OEMBED', False))
-
-settings.CHARTWERK_AWS_PATH = os.getenv(
-    'CHARTWERK_AWS_PATH', getattr(settings, 'CHARTWERK_AWS_PATH', 'charts'))
-
-settings.CHARTWERK_CACHE_HEADER = os.getenv(
-    'CHARTWERK_CACHE_HEADER',
-    getattr(settings, 'CHARTWERK_CACHE_HEADER', 'max-age=300'))
-
-settings.CHARTWERK_JQUERY = os.getenv(
-    'CHARTWERK_JQUERY',
-    getattr(
-        settings,
-        'CHARTWERK_JQUERY',
-        'https://code.jquery.com/jquery-3.2.1.slim.min.js'
-    ))
-
-settings.CHARTWERK_AUTH_DECORATOR = os.getenv(
-    'CHARTWERK_AUTH_DECORATOR',
-    getattr(
-        settings,
-        'CHARTWERK_AUTH_DECORATOR',
-        'django.contrib.auth.decorators.login_required'
-    ))
-
-settings.CHARTWERK_COLOR_SCHEMES = getattr(
-    settings,
-    'CHARTWERK_COLOR_SCHEMES',
-    {}
+missing_required_msg = (
+    'You haven\'t set the required %s variable. '
+    'Set it in your project settings.'
 )
+
+if not hasattr(settings, 'CHARTWERK_DOMAIN'):
+    raise ChartwerkConfigError(missing_required_msg % 'CHARTWERK_DOMAIN')
+
+if not hasattr(settings, 'CHARTWERK_EMBED_SCRIPT'):
+    raise ChartwerkConfigError(missing_required_msg % 'CHARTWERK_EMBED_SCRIPT')
+
+if not hasattr(settings, 'CHARTWERK_AWS_BUCKET'):
+    raise ChartwerkConfigError(missing_required_msg % 'CHARTWERK_AWS_BUCKET')
+
+if not hasattr(settings, 'AWS_ACCESS_KEY_ID'):
+    raise ChartwerkConfigError(missing_required_msg % 'AWS_ACCESS_KEY_ID')
+
+if not hasattr(settings, 'AWS_SECRET_ACCESS_KEY'):
+    raise ChartwerkConfigError(missing_required_msg % 'AWS_SECRET_ACCESS_KEY')
+
 
 #####################
 # OPTIONAL SETTINGS #
 #####################
 
-if bool(os.getenv('CHARTWERK_GITHUB_PASSWORD', False)):
-    if not bool(os.getenv('CHARTWERK_GITHUB_USER', False)):
-        raise ChartwerkConfigError('You set the CHARTWERK_GITHUB_PASSWORD \
-variable, but you haven\'t set the CHARTWERK_GITHUB_USER variable. \
-Set it as an environment variable.')
+required_together_msg = (
+    'You\'ve set the %s variable, but you haven\'t set the %s variable. '
+    'Set it in your project settings.'
+)
 
-
-if bool(os.getenv('CHARTWERK_GITHUB_USER', False)):
-    if not bool(os.getenv('CHARTWERK_GITHUB_PASSWORD', False)):
-        raise ChartwerkConfigError('You set the CHARTWERK_GITHUB_USER \
-variable, but you haven\'t set the CHARTWERK_GITHUB_PASSWORD \
-variable. Set it as an environment variable.')
-
-    settings.CHARTWERK_GITHUB_REPO = os.getenv(
-        'CHARTWERK_GITHUB_REPO',
-        getattr(
-            settings,
-            'CHARTWERK_GITHUB_REPO',
-            'chartwerk_chart-templates'
-        ))
-
-    settings.CHARTWERK_GITHUB_ORG = os.getenv(
-        'CHARTWERK_GITHUB_ORG',
-        getattr(
-            settings,
-            'CHARTWERK_GITHUB_ORG',
-            None
-        ))
-
-
-settings.CHARTWERK_SLACK_CHANNEL = os.getenv(
-    'CHARTWERK_SLACK_CHANNEL',
-    getattr(
-        settings,
-        'CHARTWERK_SLACK_CHANNEL',
-        '#chartwerk'
+if hasattr(settings, 'CHARTWERK_GITHUB_PASSWORD') and \
+        not hasattr(settings, 'CHARTWERK_GITHUB_USER'):
+    raise ChartwerkConfigError(required_together_msg % (
+        'CHARTWERK_GITHUB_PASSWORD', 'CHARTWERK_GITHUB_USER',
     ))
 
-if settings.CHARTWERK_SLACK_CHANNEL:
-    if bool(os.getenv('CHARTWERK_SLACK_TOKEN', False)):
-        raise ChartwerkConfigError('You set the CHARTWERK_SLACK_CHANNEL \
-variable, but you haven\'t set the CHARTWERK_SLACK_TOKEN variable. \
-Set it as an environment variable.')
+
+if hasattr(settings, 'CHARTWERK_GITHUB_USER') and \
+        not hasattr(settings, 'CHARTWERK_GITHUB_PASSWORD'):
+    raise ChartwerkConfigError(required_together_msg % (
+        'CHARTWERK_GITHUB_USER', 'CHARTWERK_GITHUB_PASSWORD',
+    ))
+
+
+if hasattr(settings, 'CHARTWERK_SLACK_CHANNEL') and \
+        not hasattr(settings, 'CHARTWERK_SLACK_TOKEN'):
+    raise ChartwerkConfigError(required_together_msg % (
+        'CHARTWERK_SLACK_CHANNEL', 'CHARTWERK_SLACK_TOKEN',
+    ))
+
 
 #####################
 # DATABASE SETTINGS #

--- a/chartwerk/exceptions.py
+++ b/chartwerk/exceptions.py
@@ -1,0 +1,5 @@
+from django.core.exceptions import ImproperlyConfigured
+
+
+class ChartwerkConfigError(ImproperlyConfigured):
+    pass

--- a/chartwerk/tasks/aws.py
+++ b/chartwerk/tasks/aws.py
@@ -16,7 +16,7 @@ from chartwerk.models import Chart
 logger = logging.getLogger(__name__)
 
 DOMAIN = settings.CHARTWERK_DOMAIN
-CACHE_HEADER = settings.CHARTWERK_CACHE_HEADER
+CACHE_HEADER = getattr(settings, 'CHARTWERK_CACHE_HEADER', 'max-age=300')
 
 
 def get_chartwerk_bucket():

--- a/chartwerk/views.py
+++ b/chartwerk/views.py
@@ -50,7 +50,12 @@ def secure(view):
     Can also be 'django.contrib.admin.views.decorators.staff_member_required'
     or a custom decorator.
     """
-    auth_decorator = import_auth(settings.CHARTWERK_AUTH_DECORATOR)
+    auth_module_path = getattr(
+        settings,
+        'CHARTWERK_AUTH_DECORATOR',
+        'django.contrib.auth.decorators.login_required'
+    )
+    auth_decorator = import_auth(auth_module_path)
     return (
         view if settings.DEBUG
         else method_decorator(auth_decorator, name='dispatch')(view)


### PR DESCRIPTION
This makes two changes, both related to settings:
1. Stops altering Django settings outside of the project's designated settings file (see https://docs.djangoproject.com/en/1.11/topics/settings/#altering-settings-at-runtime)
2. Eliminates all cases where the app was directly reading environment variables, preferring to draw everything from the settings. This helps make everything a bit more deterministic, but more importantly will make the app way easier to test in the future, if we want to add tests.