### PR TITLE
Make CHARTWERK_EMBED_TEMPLATE_CONTEXT a static method

### DIFF
--- a/chartwerk/conf.py
+++ b/chartwerk/conf.py
@@ -84,7 +84,7 @@ if not callable(EMBED_TEMPLATE_CONTEXT):
     raise ChartwerkConfigError('CHARTWERK_EMBED_TEMPLATE_CONTEXT must be a \
 function that accepts one parameter, the chart object.')
 
-Settings.EMBED_TEMPLATE_CONTEXT = EMBED_TEMPLATE_CONTEXT
+Settings.EMBED_TEMPLATE_CONTEXT = staticmethod(EMBED_TEMPLATE_CONTEXT)
 
 Settings.OEMBED = getattr(project_settings, 'CHARTWERK_OEMBED', False)
 


### PR DESCRIPTION
This should fix the below error:

```
TypeError at /chartwerk/api/oembed/
unbound method <lambda>() must be called with Settings instance as first argument (got Chart instance instead)
```

This happens when defining a custom `CHARTWERK_EMBED_TEMPLATE_CONTEXT` in settings.py or when using the default one.