### PR TITLE
Fixes #71. Reduce extra, duplicate queries

### DIFF
--- a/chartwerk/templates/chartwerk/browse.html
+++ b/chartwerk/templates/chartwerk/browse.html
@@ -54,7 +54,7 @@
 <li>
   <div class="clearfix">
     <div class="icon">
-      <img src="{{chart.data.template.title|get_icon}}" />
+      <img src="{{ chart.icon }}" />
     </div>
     <div class="info">
       <h3>

--- a/chartwerk/templates/chartwerk/myWerk.html
+++ b/chartwerk/templates/chartwerk/myWerk.html
@@ -48,7 +48,7 @@
 <li>
   <div class="clearfix">
     <div class="icon">
-      <img src="{{chart.data.template.title|get_icon}}" />
+      <img src="{{chart.icon}}" />
     </div>
     <div class="info">
       <h3>

--- a/chartwerk/templates/chartwerk/start.html
+++ b/chartwerk/templates/chartwerk/start.html
@@ -60,7 +60,7 @@
       </h3>
       <p><span class="count">{{template.chart_count|intcomma}}</span> charts built</p>
       <p class="credit">
-        Last updated by <span class="author">{{template.author|user_by_email}}</span> on <span>{{template.updated|date:"M. d, Y"}}</span>
+        Last updated by <span class="author">{{ template.author_name }}</span> on <span>{{template.updated|date:"M. d, Y"}}</span>
       </p>
       <i
         class="fa fa-info"

--- a/chartwerk/templatetags/chartwerk_tags.py
+++ b/chartwerk/templatetags/chartwerk_tags.py
@@ -1,13 +1,8 @@
 import json
-import os
 
-from chartwerk.models import Template
 from django import template
-from django.conf import settings
 from django.contrib.auth.models import User
-from django.contrib.staticfiles.templatetags.staticfiles import static
 
-DOMAIN = settings.CHARTWERK_DOMAIN
 
 register = template.Library()
 
@@ -30,18 +25,3 @@ def user_by_email(email):
             )
     else:
         return email
-
-
-@register.filter
-def get_icon(title):
-    default = os.path.join(
-        DOMAIN,
-        static('chartwerk/img/chartwerk_100.png')[1:]
-    )
-    if title is None:
-        return default
-    template = Template.objects.filter(title=title).first()
-    if template and template.icon:
-        return Template.objects.filter(title=title).first().icon.url
-    else:
-        return default

--- a/chartwerk/templatetags/chartwerk_tags.py
+++ b/chartwerk/templatetags/chartwerk_tags.py
@@ -10,18 +10,3 @@ register = template.Library()
 @register.filter
 def jsonify(value):
     return json.dumps(value)
-
-
-@register.filter
-def user_by_email(email):
-    if email is None:
-        return 'DEBUGGER'
-    user = User.objects.filter(email=email).first()
-    if user:
-        if user.first_name != '' and user.last_name != '':
-            return '{} {}'.format(
-                user.first_name,
-                user.last_name
-            )
-    else:
-        return email

--- a/chartwerk/views.py
+++ b/chartwerk/views.py
@@ -73,21 +73,11 @@ def build_context(context, request, chart_id='', template_id=''):
     return context
 
 
-@secure
-class Home(TemplateView):
-    template_name = 'chartwerk/home.html'
-
-
-@secure
-class Browse(ListView):
-    context_object_name = 'charts'
-    template_name = 'chartwerk/browse.html'
-    queryset = Chart.objects.all().order_by('-pk')
-
+class ChartIconMixin(object):
+    """Associate charts with templates here, to avoid lots of extra queries
+    during template rendering"""
     def get_context_data(self, **kwargs):
-        """Associate charts with templates here, to avoid lots of extra
-        queries during template rendering"""
-        context = super(Browse, self).get_context_data(**kwargs)
+        context = super(ChartIconMixin, self).get_context_data(**kwargs)
 
         # Get all the template icons and them in a dict we can use as a
         # lookup
@@ -110,6 +100,18 @@ class Browse(ListView):
 
 
 @secure
+class Home(TemplateView):
+    template_name = 'chartwerk/home.html'
+
+
+@secure
+class Browse(ChartIconMixin, ListView):
+    context_object_name = 'charts'
+    template_name = 'chartwerk/browse.html'
+    queryset = Chart.objects.all().order_by('-pk')
+
+
+@secure
 class Start(ListView):
     context_object_name = 'templates'
     template_name = 'chartwerk/start.html'
@@ -117,7 +119,7 @@ class Start(ListView):
 
 
 @secure
-class MyWerk(ListView):
+class MyWerk(ChartIconMixin, ListView):
     context_object_name = 'charts'
     template_name = 'chartwerk/myWerk.html'
     queryset = Chart.objects.all().order_by('-pk')


### PR DESCRIPTION
We were seeing lots of duplicated queries (~2 per chart) on the `browse/` page. Given the number of charts we've accumulated, it was a big hit (1,080 queries for 560 charts). We also were seeing one/two-query-per-item behavior on the `/myWerk/` and `/start/` pages, but given the much lower volume those were much less of an issue.

This PR addresses all but one of the duplicate query issues and the unaddressed one (calls to `Template.chart_count()`) is pretty minor by comparison.

The fix, in both cases, is for us to pre-query the related models and join them in the view rather than requesting them in the template.