### PR TITLE
Bugfix/relaxed dependency versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## 0.5.20 - TK
+### Changed
+- Broadened version tolerances for some dependencies.
+
 ## [0.5.17] - 2017-12-02
 ### Added
 - JS compiler subprocess

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,19 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 - Broadened version tolerances for some dependencies.
 
+## [0.5.19] - 2018-02-14
+TK
+
+## [0.5.18] - 2018-01-02
+TK
+
 ## [0.5.17] - 2017-12-02
 ### Added
 - JS compiler subprocess
 - Example app in repo
+
+## [0.5.16] - 2017-10-13
+TK
 
 ## [0.5.15] - 2017-09-15
 ### Changed
@@ -42,6 +51,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Initial commit of pluggable Django app.
 
-[Unreleased]: https://github.com/DallasMorningNews/django-chartwerk/compare/v0.0.4...HEAD
-[0.0.4]: https://github.com/DallasMorningNews/django-chartwerk/compare/v0.0.3...v0.0.4
-[0.0.3]: https://github.com/DallasMorningNews/django-chartwerk/compare/v0.0.2...v0.0.3
+[Unreleased]: https://github.com/DallasMorningNews/django-chartwerk/compare/v0.5.19...HEAD
+[0.5.19]: https://github.com/DallasMorningNews/django-chartwerk/compare/v0.5.18...v0.5.19
+[0.5.18]: https://github.com/DallasMorningNews/django-chartwerk/compare/v0.5.17...v0.5.18
+[0.5.17]: https://github.com/DallasMorningNews/django-chartwerk/compare/v0.5.16...v0.5.17
+[0.5.16]: https://github.com/DallasMorningNews/django-chartwerk/compare/v0.5.15...v0.5.16
+[0.5.15]: https://github.com/DallasMorningNews/django-chartwerk/compare/v0.5.0...v0.5.15
+[0.5.0]: https://github.com/DallasMorningNews/django-chartwerk/compare/0.0.4...v0.5.0
+[0.0.4]: https://github.com/DallasMorningNews/django-chartwerk/compare/0.0.3...0.0.4
+[0.0.3]: https://github.com/DallasMorningNews/django-chartwerk/compare/0.0.2...0.0.3

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 
 REPO_URL = 'https://github.com/DallasMorningNews/django-chartwerk/'
 
-PYPI_VERSION = '0.5.19'
+PYPI_VERSION = '0.5.20'
 
 with open(os.path.join(os.path.dirname(__file__), 'README.rst')) as readme:
     README = readme.read()
@@ -52,12 +52,12 @@ setup(
         'Topic :: Internet :: WWW/HTTP :: Dynamic Content',
     ],
     install_requires=[
-        'boto3>=1.4.0',
-        'celery>=4.0.0',
+        'boto3>=1.4',
+        'celery>=4.0',
         'django-uuslug>=1.1.8',
         'djangorestframework>=2.4',
         'Pillow',
-        'psycopg2>=2.5.4',
+        'psycopg2>=2.5',
         'PyGithub>=1.29',
         'slacker>=0.9',
     ],

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,6 @@ setup(
         'django-uuslug>=1.1.8',
         'djangorestframework>=2.4',
         'Pillow',
-        'psycopg2>=2.5',
         'PyGithub>=1.29',
         'slacker>=0.9',
     ],


### PR DESCRIPTION
We're getting some version-mismatch errors when trying to install our pip dependencies.

The culprit appears to be [this line](https://github.com/DallasMorningNews/django-chartwerk/blob/0974e2b075a8192fac3c593c32c8d521d58bf2a3/setup.py#L55) in this project's `setup.py` file (installing any boto3 version `>=1.4.0`).

Contrary to what we'd assumed that operator does, it will only install other versions within the `1.4.x` series — not any other `1.x.y` release as one might expect. For that behavior you need to use the extremely similar `>=1.4` syntax.

Changing this for boto seems to fix our dependency issues, since the more relaxed operator allows for a newer version. I've gone through and updated most of the dependencies that use the greater-or-equal operator, so they now accept all minor and patch versions under the given major version.

Dependencies that'll be updated include:

-   `boto3`: Prior max version `1.4.8`; new max version `1.8.3`
-   `celery`: Prior max version `4.0.2`; new max version `4.2.1`
-   `psycopg2`: Prior max version `2.5.4`; new max version `2.7.5`

Let me know what y'all think. We'd definitely like to get this merged in as soon as we can.